### PR TITLE
GKO-1280: improve handling of time fields in subscriptions

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,17 +1,17 @@
 lockVersion: 2.0.0
 id: b5451c3d-2473-444c-bd62-9bf8987cd90b
 management:
-  docChecksum: 7dac7546a030c3a1b508102799f1ebc1
+  docChecksum: 692f3018f402f28138d69e8b3e742055
   docVersion: 1.0.0
-  speakeasyVersion: 1.599.0
-  generationVersion: 2.675.0
+  speakeasyVersion: 1.604.1
+  generationVersion: 2.683.1
   releaseVersion: 0.3.0
   configChecksum: 46047f5b540d2cc85a4d36dd35c8074a
 features:
   terraform:
     additionalDependencies: 0.1.0
     constsAndDefaults: 0.2.1
-    core: 3.43.1
+    core: 3.44.1
     globalSecurity: 2.81.12
     globalServerURLs: 2.83.0
     globals: 3.0.0

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.599.0
+speakeasyVersion: 1.604.1
 sources:
     Gravitee.io - Automation API:
         sourceNamespace: gravitee-io-gko---automation-api

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-docs v0.20.1
 	github.com/hashicorp/terraform-plugin-framework v1.15.0
+	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
+	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.17.0
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,10 @@ github.com/hashicorp/terraform-plugin-docs v0.20.1 h1:Fq7E/HrU8kuZu3hNliZGwloFWS
 github.com/hashicorp/terraform-plugin-docs v0.20.1/go.mod h1:Yz6HoK7/EgzSrHPB9J/lWFzwl9/xep2OPnc5jaJDV90=
 github.com/hashicorp/terraform-plugin-framework v1.15.0 h1:LQ2rsOfmDLxcn5EeIwdXFtr03FVsNktbbBci8cOKdb4=
 github.com/hashicorp/terraform-plugin-framework v1.15.0/go.mod h1:hxrNI/GY32KPISpWqlCoTLM9JZsGH3CyYlir09bD/fI=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0 h1:SJXL5FfJJm17554Kpt9jFXngdM6fXbnUnZ6iT2IeiYA=
+github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0/go.mod h1:p0phD0IYhsu9bR4+6OetVvvH59I6LwjXGnTVEr8ox6E=
+github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0 h1:v3DapR8gsp3EM8fKMh6up9cJUFQ2iRaFsYLP8UJnCco=
+github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0/go.mod h1:c3PnGE9pHBDfdEVG9t1S1C9ia5LW+gkFR0CygXlM8ak=
 github.com/hashicorp/terraform-plugin-framework-validators v0.17.0 h1:0uYQcqqgW3BMyyve07WJgpKorXST3zkpzvrOnf3mpbg=
 github.com/hashicorp/terraform-plugin-framework-validators v0.17.0/go.mod h1:VwdfgE/5Zxm43flraNa0VjcvKQOGVrcO4X8peIri0T0=
 github.com/hashicorp/terraform-plugin-go v0.28.0 h1:zJmu2UDwhVN0J+J20RE5huiF3XXlTYVIleaevHZgKPA=

--- a/internal/provider/apiv4_data_source.go
+++ b/internal/provider/apiv4_data_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	tfTypes "github.com/gravitee-io/terraform-provider-apim/internal/provider/types"
 	"github.com/gravitee-io/terraform-provider-apim/internal/sdk"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -200,6 +201,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"configuration": schema.StringAttribute{
+										CustomType:  jsontypes.NormalizedType{},
 										Computed:    true,
 										Description: `Parsed as JSON.`,
 									},
@@ -222,6 +224,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 												Computed: true,
 												Attributes: map[string]schema.Attribute{
 													"configuration": schema.StringAttribute{
+														CustomType:  jsontypes.NormalizedType{},
 														Computed:    true,
 														Description: `The configuration of the service. Parsed as JSON.`,
 													},
@@ -243,6 +246,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 										Description: `API Endpoint Services`,
 									},
 									"shared_configuration_override": schema.StringAttribute{
+										CustomType:  jsontypes.NormalizedType{},
 										Computed:    true,
 										Description: `Parsed as JSON.`,
 									},
@@ -283,6 +287,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 									Computed: true,
 									Attributes: map[string]schema.Attribute{
 										"configuration": schema.StringAttribute{
+											CustomType:  jsontypes.NormalizedType{},
 											Computed:    true,
 											Description: `The configuration of the service. Parsed as JSON.`,
 										},
@@ -304,6 +309,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 									Computed: true,
 									Attributes: map[string]schema.Attribute{
 										"configuration": schema.StringAttribute{
+											CustomType:  jsontypes.NormalizedType{},
 											Computed:    true,
 											Description: `The configuration of the service. Parsed as JSON.`,
 										},
@@ -325,6 +331,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 							Description: `API Endpoint Group Services`,
 						},
 						"shared_configuration": schema.StringAttribute{
+							CustomType:  jsontypes.NormalizedType{},
 							Computed:    true,
 							Description: `Parsed as JSON.`,
 						},
@@ -397,6 +404,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 										Description: `The condition of the step`,
 									},
 									"configuration": schema.StringAttribute{
+										CustomType:  jsontypes.NormalizedType{},
 										Computed:    true,
 										Description: `The configuration of the step. Parsed as JSON.`,
 									},
@@ -441,6 +449,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 										Description: `The condition of the step`,
 									},
 									"configuration": schema.StringAttribute{
+										CustomType:  jsontypes.NormalizedType{},
 										Computed:    true,
 										Description: `The configuration of the step. Parsed as JSON.`,
 									},
@@ -481,6 +490,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 										Description: `The condition of the step`,
 									},
 									"configuration": schema.StringAttribute{
+										CustomType:  jsontypes.NormalizedType{},
 										Computed:    true,
 										Description: `The configuration of the step. Parsed as JSON.`,
 									},
@@ -517,6 +527,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 										Description: `The condition of the step`,
 									},
 									"configuration": schema.StringAttribute{
+										CustomType:  jsontypes.NormalizedType{},
 										Computed:    true,
 										Description: `The configuration of the step. Parsed as JSON.`,
 									},
@@ -553,6 +564,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 										Description: `The condition of the step`,
 									},
 									"configuration": schema.StringAttribute{
+										CustomType:  jsontypes.NormalizedType{},
 										Computed:    true,
 										Description: `The configuration of the step. Parsed as JSON.`,
 									},
@@ -659,6 +671,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 										Description: `The condition of the step`,
 									},
 									"configuration": schema.StringAttribute{
+										CustomType:  jsontypes.NormalizedType{},
 										Computed:    true,
 										Description: `The configuration of the step. Parsed as JSON.`,
 									},
@@ -767,6 +780,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"configuration": schema.StringAttribute{
+												CustomType:  jsontypes.NormalizedType{},
 												Computed:    true,
 												Description: `Parsed as JSON.`,
 											},
@@ -830,6 +844,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"configuration": schema.StringAttribute{
+												CustomType:  jsontypes.NormalizedType{},
 												Computed:    true,
 												Description: `Parsed as JSON.`,
 											},
@@ -881,6 +896,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"configuration": schema.StringAttribute{
+												CustomType:  jsontypes.NormalizedType{},
 												Computed:    true,
 												Description: `Parsed as JSON.`,
 											},
@@ -924,6 +940,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 									NestedObject: schema.NestedAttributeObject{
 										Attributes: map[string]schema.Attribute{
 											"configuration": schema.StringAttribute{
+												CustomType:  jsontypes.NormalizedType{},
 												Computed:    true,
 												Description: `Parsed as JSON.`,
 											},
@@ -1153,6 +1170,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 							Computed: true,
 							Attributes: map[string]schema.Attribute{
 								"configuration": schema.StringAttribute{
+									CustomType:  jsontypes.NormalizedType{},
 									Computed:    true,
 									Description: `Page source's configuration. Parsed as JSON.`,
 								},
@@ -1287,6 +1305,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 										Computed: true,
 										Attributes: map[string]schema.Attribute{
 											"configuration": schema.StringAttribute{
+												CustomType:  jsontypes.NormalizedType{},
 												Computed:    true,
 												Description: `Page source's configuration. Parsed as JSON.`,
 											},
@@ -1357,6 +1376,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 													Description: `The condition of the step`,
 												},
 												"configuration": schema.StringAttribute{
+													CustomType:  jsontypes.NormalizedType{},
 													Computed:    true,
 													Description: `The configuration of the step. Parsed as JSON.`,
 												},
@@ -1401,6 +1421,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 													Description: `The condition of the step`,
 												},
 												"configuration": schema.StringAttribute{
+													CustomType:  jsontypes.NormalizedType{},
 													Computed:    true,
 													Description: `The configuration of the step. Parsed as JSON.`,
 												},
@@ -1441,6 +1462,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 													Description: `The condition of the step`,
 												},
 												"configuration": schema.StringAttribute{
+													CustomType:  jsontypes.NormalizedType{},
 													Computed:    true,
 													Description: `The configuration of the step. Parsed as JSON.`,
 												},
@@ -1477,6 +1499,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 													Description: `The condition of the step`,
 												},
 												"configuration": schema.StringAttribute{
+													CustomType:  jsontypes.NormalizedType{},
 													Computed:    true,
 													Description: `The configuration of the step. Parsed as JSON.`,
 												},
@@ -1513,6 +1536,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 													Description: `The condition of the step`,
 												},
 												"configuration": schema.StringAttribute{
+													CustomType:  jsontypes.NormalizedType{},
 													Computed:    true,
 													Description: `The configuration of the step. Parsed as JSON.`,
 												},
@@ -1619,6 +1643,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 													Description: `The condition of the step`,
 												},
 												"configuration": schema.StringAttribute{
+													CustomType:  jsontypes.NormalizedType{},
 													Computed:    true,
 													Description: `The configuration of the step. Parsed as JSON.`,
 												},
@@ -1672,6 +1697,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 							Computed: true,
 							Attributes: map[string]schema.Attribute{
 								"configuration": schema.StringAttribute{
+									CustomType:  jsontypes.NormalizedType{},
 									Computed:    true,
 									Description: `Parsed as JSON.`,
 								},
@@ -1755,6 +1781,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"configuration": schema.StringAttribute{
+							CustomType:  jsontypes.NormalizedType{},
 							Computed:    true,
 							Description: `Resource configuration. Parsed as JSON.`,
 						},
@@ -1796,6 +1823,7 @@ func (r *Apiv4DataSource) Schema(ctx context.Context, req datasource.SchemaReque
 						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"configuration": schema.StringAttribute{
+								CustomType:  jsontypes.NormalizedType{},
 								Computed:    true,
 								Description: `The configuration of the service. Parsed as JSON.`,
 							},

--- a/internal/provider/apiv4_data_source_sdk.go
+++ b/internal/provider/apiv4_data_source_sdk.go
@@ -9,6 +9,7 @@ import (
 	tfTypes "github.com/gravitee-io/terraform-provider-apim/internal/provider/types"
 	"github.com/gravitee-io/terraform-provider-apim/internal/sdk/models/operations"
 	"github.com/gravitee-io/terraform-provider-apim/internal/sdk/models/shared"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -85,10 +86,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 				var endpoints tfTypes.EndpointV4
 
 				if endpointsItem.Configuration == nil {
-					endpoints.Configuration = types.StringNull()
+					endpoints.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult, _ := json.Marshal(endpointsItem.Configuration)
-					endpoints.Configuration = types.StringValue(string(configurationResult))
+					endpoints.Configuration = jsontypes.NewNormalizedValue(string(configurationResult))
 				}
 				endpoints.InheritConfiguration = types.BoolPointerValue(endpointsItem.InheritConfiguration)
 				endpoints.Name = types.StringPointerValue(endpointsItem.Name)
@@ -102,10 +103,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 					} else {
 						endpoints.Services.HealthCheck = &tfTypes.ServiceV4{}
 						if endpointsItem.Services.HealthCheck.Configuration == nil {
-							endpoints.Services.HealthCheck.Configuration = types.StringNull()
+							endpoints.Services.HealthCheck.Configuration = jsontypes.NewNormalizedNull()
 						} else {
 							configurationResult1, _ := json.Marshal(endpointsItem.Services.HealthCheck.Configuration)
-							endpoints.Services.HealthCheck.Configuration = types.StringValue(string(configurationResult1))
+							endpoints.Services.HealthCheck.Configuration = jsontypes.NewNormalizedValue(string(configurationResult1))
 						}
 						endpoints.Services.HealthCheck.Enabled = types.BoolPointerValue(endpointsItem.Services.HealthCheck.Enabled)
 						endpoints.Services.HealthCheck.OverrideConfiguration = types.BoolPointerValue(endpointsItem.Services.HealthCheck.OverrideConfiguration)
@@ -113,10 +114,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 					}
 				}
 				if endpointsItem.SharedConfigurationOverride == nil {
-					endpoints.SharedConfigurationOverride = types.StringNull()
+					endpoints.SharedConfigurationOverride = jsontypes.NewNormalizedNull()
 				} else {
 					sharedConfigurationOverrideResult, _ := json.Marshal(endpointsItem.SharedConfigurationOverride)
-					endpoints.SharedConfigurationOverride = types.StringValue(string(sharedConfigurationOverrideResult))
+					endpoints.SharedConfigurationOverride = jsontypes.NewNormalizedValue(string(sharedConfigurationOverrideResult))
 				}
 				endpoints.Tenants = make([]types.String, 0, len(endpointsItem.Tenants))
 				for _, v := range endpointsItem.Tenants {
@@ -147,10 +148,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 				} else {
 					endpointGroups.Services.Discovery = &tfTypes.ServiceV4{}
 					if endpointGroupsItem.Services.Discovery.Configuration == nil {
-						endpointGroups.Services.Discovery.Configuration = types.StringNull()
+						endpointGroups.Services.Discovery.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult2, _ := json.Marshal(endpointGroupsItem.Services.Discovery.Configuration)
-						endpointGroups.Services.Discovery.Configuration = types.StringValue(string(configurationResult2))
+						endpointGroups.Services.Discovery.Configuration = jsontypes.NewNormalizedValue(string(configurationResult2))
 					}
 					endpointGroups.Services.Discovery.Enabled = types.BoolPointerValue(endpointGroupsItem.Services.Discovery.Enabled)
 					endpointGroups.Services.Discovery.OverrideConfiguration = types.BoolPointerValue(endpointGroupsItem.Services.Discovery.OverrideConfiguration)
@@ -161,10 +162,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 				} else {
 					endpointGroups.Services.HealthCheck = &tfTypes.ServiceV4{}
 					if endpointGroupsItem.Services.HealthCheck.Configuration == nil {
-						endpointGroups.Services.HealthCheck.Configuration = types.StringNull()
+						endpointGroups.Services.HealthCheck.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult3, _ := json.Marshal(endpointGroupsItem.Services.HealthCheck.Configuration)
-						endpointGroups.Services.HealthCheck.Configuration = types.StringValue(string(configurationResult3))
+						endpointGroups.Services.HealthCheck.Configuration = jsontypes.NewNormalizedValue(string(configurationResult3))
 					}
 					endpointGroups.Services.HealthCheck.Enabled = types.BoolPointerValue(endpointGroupsItem.Services.HealthCheck.Enabled)
 					endpointGroups.Services.HealthCheck.OverrideConfiguration = types.BoolPointerValue(endpointGroupsItem.Services.HealthCheck.OverrideConfiguration)
@@ -172,10 +173,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 				}
 			}
 			if endpointGroupsItem.SharedConfiguration == nil {
-				endpointGroups.SharedConfiguration = types.StringNull()
+				endpointGroups.SharedConfiguration = jsontypes.NewNormalizedNull()
 			} else {
 				sharedConfigurationResult, _ := json.Marshal(endpointGroupsItem.SharedConfiguration)
-				endpointGroups.SharedConfiguration = types.StringValue(string(sharedConfigurationResult))
+				endpointGroups.SharedConfiguration = jsontypes.NewNormalizedValue(string(sharedConfigurationResult))
 			}
 			endpointGroups.Type = types.StringValue(endpointGroupsItem.Type)
 
@@ -215,10 +216,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 
 				connect.Condition = types.StringPointerValue(connectItem.Condition)
 				if connectItem.Configuration == nil {
-					connect.Configuration = types.StringNull()
+					connect.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult4, _ := json.Marshal(connectItem.Configuration)
-					connect.Configuration = types.StringValue(string(configurationResult4))
+					connect.Configuration = jsontypes.NewNormalizedValue(string(configurationResult4))
 				}
 				connect.Description = types.StringPointerValue(connectItem.Description)
 				connect.Enabled = types.BoolPointerValue(connectItem.Enabled)
@@ -237,10 +238,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 
 				interact.Condition = types.StringPointerValue(interactItem.Condition)
 				if interactItem.Configuration == nil {
-					interact.Configuration = types.StringNull()
+					interact.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult5, _ := json.Marshal(interactItem.Configuration)
-					interact.Configuration = types.StringValue(string(configurationResult5))
+					interact.Configuration = jsontypes.NewNormalizedValue(string(configurationResult5))
 				}
 				interact.Description = types.StringPointerValue(interactItem.Description)
 				interact.Enabled = types.BoolPointerValue(interactItem.Enabled)
@@ -258,10 +259,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 
 				publish.Condition = types.StringPointerValue(publishItem.Condition)
 				if publishItem.Configuration == nil {
-					publish.Configuration = types.StringNull()
+					publish.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult6, _ := json.Marshal(publishItem.Configuration)
-					publish.Configuration = types.StringValue(string(configurationResult6))
+					publish.Configuration = jsontypes.NewNormalizedValue(string(configurationResult6))
 				}
 				publish.Description = types.StringPointerValue(publishItem.Description)
 				publish.Enabled = types.BoolPointerValue(publishItem.Enabled)
@@ -278,10 +279,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 
 				request.Condition = types.StringPointerValue(requestItem.Condition)
 				if requestItem.Configuration == nil {
-					request.Configuration = types.StringNull()
+					request.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult7, _ := json.Marshal(requestItem.Configuration)
-					request.Configuration = types.StringValue(string(configurationResult7))
+					request.Configuration = jsontypes.NewNormalizedValue(string(configurationResult7))
 				}
 				request.Description = types.StringPointerValue(requestItem.Description)
 				request.Enabled = types.BoolPointerValue(requestItem.Enabled)
@@ -298,10 +299,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 
 				response.Condition = types.StringPointerValue(responseItem.Condition)
 				if responseItem.Configuration == nil {
-					response.Configuration = types.StringNull()
+					response.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult8, _ := json.Marshal(responseItem.Configuration)
-					response.Configuration = types.StringValue(string(configurationResult8))
+					response.Configuration = jsontypes.NewNormalizedValue(string(configurationResult8))
 				}
 				response.Description = types.StringPointerValue(responseItem.Description)
 				response.Enabled = types.BoolPointerValue(responseItem.Enabled)
@@ -363,10 +364,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 
 				subscribe.Condition = types.StringPointerValue(subscribeItem.Condition)
 				if subscribeItem.Configuration == nil {
-					subscribe.Configuration = types.StringNull()
+					subscribe.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult9, _ := json.Marshal(subscribeItem.Configuration)
-					subscribe.Configuration = types.StringValue(string(configurationResult9))
+					subscribe.Configuration = jsontypes.NewNormalizedValue(string(configurationResult9))
 				}
 				subscribe.Description = types.StringPointerValue(subscribeItem.Description)
 				subscribe.Enabled = types.BoolPointerValue(subscribeItem.Enabled)
@@ -432,10 +433,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 					var entrypoints tfTypes.Entrypoint
 
 					if entrypointsItem.Configuration == nil {
-						entrypoints.Configuration = types.StringNull()
+						entrypoints.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult10, _ := json.Marshal(entrypointsItem.Configuration)
-						entrypoints.Configuration = types.StringValue(string(configurationResult10))
+						entrypoints.Configuration = jsontypes.NewNormalizedValue(string(configurationResult10))
 					}
 					if entrypointsItem.Dlq == nil {
 						entrypoints.Dlq = nil
@@ -481,10 +482,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 					var entrypoints1 tfTypes.Entrypoint
 
 					if entrypointsItem1.Configuration == nil {
-						entrypoints1.Configuration = types.StringNull()
+						entrypoints1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult11, _ := json.Marshal(entrypointsItem1.Configuration)
-						entrypoints1.Configuration = types.StringValue(string(configurationResult11))
+						entrypoints1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult11))
 					}
 					if entrypointsItem1.Dlq == nil {
 						entrypoints1.Dlq = nil
@@ -517,10 +518,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 					var entrypoints2 tfTypes.Entrypoint
 
 					if entrypointsItem2.Configuration == nil {
-						entrypoints2.Configuration = types.StringNull()
+						entrypoints2.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult12, _ := json.Marshal(entrypointsItem2.Configuration)
-						entrypoints2.Configuration = types.StringValue(string(configurationResult12))
+						entrypoints2.Configuration = jsontypes.NewNormalizedValue(string(configurationResult12))
 					}
 					if entrypointsItem2.Dlq == nil {
 						entrypoints2.Dlq = nil
@@ -551,10 +552,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 					var entrypoints3 tfTypes.Entrypoint
 
 					if entrypointsItem3.Configuration == nil {
-						entrypoints3.Configuration = types.StringNull()
+						entrypoints3.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult13, _ := json.Marshal(entrypointsItem3.Configuration)
-						entrypoints3.Configuration = types.StringValue(string(configurationResult13))
+						entrypoints3.Configuration = jsontypes.NewNormalizedValue(string(configurationResult13))
 					}
 					if entrypointsItem3.Dlq == nil {
 						entrypoints3.Dlq = nil
@@ -674,10 +675,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 			} else {
 				pages.Source = &tfTypes.PageSource{}
 				if pagesItem.Source.Configuration == nil {
-					pages.Source.Configuration = types.StringNull()
+					pages.Source.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult14, _ := json.Marshal(pagesItem.Source.Configuration)
-					pages.Source.Configuration = types.StringValue(string(configurationResult14))
+					pages.Source.Configuration = jsontypes.NewNormalizedValue(string(configurationResult14))
 				}
 				pages.Source.Type = types.StringPointerValue(pagesItem.Source.Type)
 			}
@@ -745,10 +746,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 				} else {
 					translations.Source = &tfTypes.PageSource{}
 					if translationsItem.Source.Configuration == nil {
-						translations.Source.Configuration = types.StringNull()
+						translations.Source.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult15, _ := json.Marshal(translationsItem.Source.Configuration)
-						translations.Source.Configuration = types.StringValue(string(configurationResult15))
+						translations.Source.Configuration = jsontypes.NewNormalizedValue(string(configurationResult15))
 					}
 					translations.Source.Type = types.StringPointerValue(translationsItem.Source.Type)
 				}
@@ -798,10 +799,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 
 					connect1.Condition = types.StringPointerValue(connectItem1.Condition)
 					if connectItem1.Configuration == nil {
-						connect1.Configuration = types.StringNull()
+						connect1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult16, _ := json.Marshal(connectItem1.Configuration)
-						connect1.Configuration = types.StringValue(string(configurationResult16))
+						connect1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult16))
 					}
 					connect1.Description = types.StringPointerValue(connectItem1.Description)
 					connect1.Enabled = types.BoolPointerValue(connectItem1.Enabled)
@@ -820,10 +821,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 
 					interact1.Condition = types.StringPointerValue(interactItem1.Condition)
 					if interactItem1.Configuration == nil {
-						interact1.Configuration = types.StringNull()
+						interact1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult17, _ := json.Marshal(interactItem1.Configuration)
-						interact1.Configuration = types.StringValue(string(configurationResult17))
+						interact1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult17))
 					}
 					interact1.Description = types.StringPointerValue(interactItem1.Description)
 					interact1.Enabled = types.BoolPointerValue(interactItem1.Enabled)
@@ -841,10 +842,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 
 					publish1.Condition = types.StringPointerValue(publishItem1.Condition)
 					if publishItem1.Configuration == nil {
-						publish1.Configuration = types.StringNull()
+						publish1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult18, _ := json.Marshal(publishItem1.Configuration)
-						publish1.Configuration = types.StringValue(string(configurationResult18))
+						publish1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult18))
 					}
 					publish1.Description = types.StringPointerValue(publishItem1.Description)
 					publish1.Enabled = types.BoolPointerValue(publishItem1.Enabled)
@@ -861,10 +862,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 
 					request1.Condition = types.StringPointerValue(requestItem1.Condition)
 					if requestItem1.Configuration == nil {
-						request1.Configuration = types.StringNull()
+						request1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult19, _ := json.Marshal(requestItem1.Configuration)
-						request1.Configuration = types.StringValue(string(configurationResult19))
+						request1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult19))
 					}
 					request1.Description = types.StringPointerValue(requestItem1.Description)
 					request1.Enabled = types.BoolPointerValue(requestItem1.Enabled)
@@ -881,10 +882,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 
 					response1.Condition = types.StringPointerValue(responseItem1.Condition)
 					if responseItem1.Configuration == nil {
-						response1.Configuration = types.StringNull()
+						response1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult20, _ := json.Marshal(responseItem1.Configuration)
-						response1.Configuration = types.StringValue(string(configurationResult20))
+						response1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult20))
 					}
 					response1.Description = types.StringPointerValue(responseItem1.Description)
 					response1.Enabled = types.BoolPointerValue(responseItem1.Enabled)
@@ -946,10 +947,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 
 					subscribe1.Condition = types.StringPointerValue(subscribeItem1.Condition)
 					if subscribeItem1.Configuration == nil {
-						subscribe1.Configuration = types.StringNull()
+						subscribe1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult21, _ := json.Marshal(subscribeItem1.Configuration)
-						subscribe1.Configuration = types.StringValue(string(configurationResult21))
+						subscribe1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult21))
 					}
 					subscribe1.Description = types.StringPointerValue(subscribeItem1.Description)
 					subscribe1.Enabled = types.BoolPointerValue(subscribeItem1.Enabled)
@@ -971,10 +972,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 			plans.Mode = types.StringValue(string(plansItem.Mode))
 			plans.Name = types.StringValue(plansItem.Name)
 			if plansItem.Security.Configuration == nil {
-				plans.Security.Configuration = types.StringNull()
+				plans.Security.Configuration = jsontypes.NewNormalizedNull()
 			} else {
 				configurationResult22, _ := json.Marshal(plansItem.Security.Configuration)
-				plans.Security.Configuration = types.StringValue(string(configurationResult22))
+				plans.Security.Configuration = jsontypes.NewNormalizedValue(string(configurationResult22))
 			}
 			plans.Security.Type = types.StringValue(string(plansItem.Security.Type))
 			plans.SelectionRule = types.StringPointerValue(plansItem.SelectionRule)
@@ -1019,7 +1020,7 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 			var resources tfTypes.Resource
 
 			configurationResult23, _ := json.Marshal(resourcesItem.Configuration)
-			resources.Configuration = types.StringValue(string(configurationResult23))
+			resources.Configuration = jsontypes.NewNormalizedValue(string(configurationResult23))
 			resources.Enabled = types.BoolPointerValue(resourcesItem.Enabled)
 			resources.Name = types.StringValue(resourcesItem.Name)
 			resources.Type = types.StringValue(resourcesItem.Type)
@@ -1060,10 +1061,10 @@ func (r *Apiv4DataSourceModel) RefreshFromSharedApiv4State(ctx context.Context, 
 			} else {
 				r.Services.DynamicProperty = &tfTypes.ServiceV4{}
 				if resp.Services.DynamicProperty.Configuration == nil {
-					r.Services.DynamicProperty.Configuration = types.StringNull()
+					r.Services.DynamicProperty.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult24, _ := json.Marshal(resp.Services.DynamicProperty.Configuration)
-					r.Services.DynamicProperty.Configuration = types.StringValue(string(configurationResult24))
+					r.Services.DynamicProperty.Configuration = jsontypes.NewNormalizedValue(string(configurationResult24))
 				}
 				r.Services.DynamicProperty.Enabled = types.BoolPointerValue(resp.Services.DynamicProperty.Enabled)
 				r.Services.DynamicProperty.OverrideConfiguration = types.BoolPointerValue(resp.Services.DynamicProperty.OverrideConfiguration)

--- a/internal/provider/apiv4_resource.go
+++ b/internal/provider/apiv4_resource.go
@@ -20,6 +20,7 @@ import (
 	speakeasy_listvalidators "github.com/gravitee-io/terraform-provider-apim/internal/validators/listvalidators"
 	speakeasy_objectvalidators "github.com/gravitee-io/terraform-provider-apim/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/gravitee-io/terraform-provider-apim/internal/validators/stringvalidators"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -354,15 +355,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 								},
 								Attributes: map[string]schema.Attribute{
 									"configuration": schema.StringAttribute{
-										Computed: true,
-										Optional: true,
+										CustomType: jsontypes.NormalizedType{},
+										Computed:   true,
+										Optional:   true,
 										PlanModifiers: []planmodifier.String{
 											speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 										},
 										Description: `Parsed as JSON.`,
-										Validators: []validator.String{
-											validators.IsValidJSON(),
-										},
 									},
 									"inherit_configuration": schema.BoolAttribute{
 										Computed: true,
@@ -405,15 +404,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 												},
 												Attributes: map[string]schema.Attribute{
 													"configuration": schema.StringAttribute{
-														Computed: true,
-														Optional: true,
+														CustomType: jsontypes.NormalizedType{},
+														Computed:   true,
+														Optional:   true,
 														PlanModifiers: []planmodifier.String{
 															speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 														},
 														Description: `The configuration of the service. Parsed as JSON.`,
-														Validators: []validator.String{
-															validators.IsValidJSON(),
-														},
 													},
 													"enabled": schema.BoolAttribute{
 														Computed: true,
@@ -447,15 +444,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Description: `API Endpoint Services`,
 									},
 									"shared_configuration_override": schema.StringAttribute{
-										Computed: true,
-										Optional: true,
+										CustomType: jsontypes.NormalizedType{},
+										Computed:   true,
+										Optional:   true,
 										PlanModifiers: []planmodifier.String{
 											speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 										},
 										Description: `Parsed as JSON.`,
-										Validators: []validator.String{
-											validators.IsValidJSON(),
-										},
 									},
 									"tenants": schema.ListAttribute{
 										Computed: true,
@@ -539,15 +534,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 									},
 									Attributes: map[string]schema.Attribute{
 										"configuration": schema.StringAttribute{
-											Computed: true,
-											Optional: true,
+											CustomType: jsontypes.NormalizedType{},
+											Computed:   true,
+											Optional:   true,
 											PlanModifiers: []planmodifier.String{
 												speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 											},
 											Description: `The configuration of the service. Parsed as JSON.`,
-											Validators: []validator.String{
-												validators.IsValidJSON(),
-											},
 										},
 										"enabled": schema.BoolAttribute{
 											Computed: true,
@@ -585,15 +578,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 									},
 									Attributes: map[string]schema.Attribute{
 										"configuration": schema.StringAttribute{
-											Computed: true,
-											Optional: true,
+											CustomType: jsontypes.NormalizedType{},
+											Computed:   true,
+											Optional:   true,
 											PlanModifiers: []planmodifier.String{
 												speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 											},
 											Description: `The configuration of the service. Parsed as JSON.`,
-											Validators: []validator.String{
-												validators.IsValidJSON(),
-											},
 										},
 										"enabled": schema.BoolAttribute{
 											Computed: true,
@@ -627,15 +618,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							Description: `API Endpoint Group Services`,
 						},
 						"shared_configuration": schema.StringAttribute{
-							Computed: true,
-							Optional: true,
+							CustomType: jsontypes.NormalizedType{},
+							Computed:   true,
+							Optional:   true,
 							PlanModifiers: []planmodifier.String{
 								speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 							},
 							Description: `Parsed as JSON.`,
-							Validators: []validator.String{
-								validators.IsValidJSON(),
-							},
 						},
 						"type": schema.StringAttribute{
 							Computed: true,
@@ -804,15 +793,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Description: `The condition of the step`,
 									},
 									"configuration": schema.StringAttribute{
-										Computed: true,
-										Optional: true,
+										CustomType: jsontypes.NormalizedType{},
+										Computed:   true,
+										Optional:   true,
 										PlanModifiers: []planmodifier.String{
 											speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 										},
 										Description: `The configuration of the step. Parsed as JSON.`,
-										Validators: []validator.String{
-											validators.IsValidJSON(),
-										},
 									},
 									"description": schema.StringAttribute{
 										Computed: true,
@@ -899,15 +886,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Description: `The condition of the step`,
 									},
 									"configuration": schema.StringAttribute{
-										Computed: true,
-										Optional: true,
+										CustomType: jsontypes.NormalizedType{},
+										Computed:   true,
+										Optional:   true,
 										PlanModifiers: []planmodifier.String{
 											speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 										},
 										Description: `The configuration of the step. Parsed as JSON.`,
-										Validators: []validator.String{
-											validators.IsValidJSON(),
-										},
 									},
 									"description": schema.StringAttribute{
 										Computed: true,
@@ -985,15 +970,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Description: `The condition of the step`,
 									},
 									"configuration": schema.StringAttribute{
-										Computed: true,
-										Optional: true,
+										CustomType: jsontypes.NormalizedType{},
+										Computed:   true,
+										Optional:   true,
 										PlanModifiers: []planmodifier.String{
 											speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 										},
 										Description: `The configuration of the step. Parsed as JSON.`,
-										Validators: []validator.String{
-											validators.IsValidJSON(),
-										},
 									},
 									"description": schema.StringAttribute{
 										Computed: true,
@@ -1063,15 +1046,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Description: `The condition of the step`,
 									},
 									"configuration": schema.StringAttribute{
-										Computed: true,
-										Optional: true,
+										CustomType: jsontypes.NormalizedType{},
+										Computed:   true,
+										Optional:   true,
 										PlanModifiers: []planmodifier.String{
 											speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 										},
 										Description: `The configuration of the step. Parsed as JSON.`,
-										Validators: []validator.String{
-											validators.IsValidJSON(),
-										},
 									},
 									"description": schema.StringAttribute{
 										Computed: true,
@@ -1141,15 +1122,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Description: `The condition of the step`,
 									},
 									"configuration": schema.StringAttribute{
-										Computed: true,
-										Optional: true,
+										CustomType: jsontypes.NormalizedType{},
+										Computed:   true,
+										Optional:   true,
 										PlanModifiers: []planmodifier.String{
 											speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 										},
 										Description: `The configuration of the step. Parsed as JSON.`,
-										Validators: []validator.String{
-											validators.IsValidJSON(),
-										},
 									},
 									"description": schema.StringAttribute{
 										Computed: true,
@@ -1425,15 +1404,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Description: `The condition of the step`,
 									},
 									"configuration": schema.StringAttribute{
-										Computed: true,
-										Optional: true,
+										CustomType: jsontypes.NormalizedType{},
+										Computed:   true,
+										Optional:   true,
 										PlanModifiers: []planmodifier.String{
 											speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 										},
 										Description: `The configuration of the step. Parsed as JSON.`,
-										Validators: []validator.String{
-											validators.IsValidJSON(),
-										},
 									},
 									"description": schema.StringAttribute{
 										Computed: true,
@@ -1670,15 +1647,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										},
 										Attributes: map[string]schema.Attribute{
 											"configuration": schema.StringAttribute{
-												Computed: true,
-												Optional: true,
+												CustomType: jsontypes.NormalizedType{},
+												Computed:   true,
+												Optional:   true,
 												PlanModifiers: []planmodifier.String{
 													speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 												},
 												Description: `Parsed as JSON.`,
-												Validators: []validator.String{
-													validators.IsValidJSON(),
-												},
 											},
 											"dlq": schema.SingleNestedAttribute{
 												Computed: true,
@@ -1842,15 +1817,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										},
 										Attributes: map[string]schema.Attribute{
 											"configuration": schema.StringAttribute{
-												Computed: true,
-												Optional: true,
+												CustomType: jsontypes.NormalizedType{},
+												Computed:   true,
+												Optional:   true,
 												PlanModifiers: []planmodifier.String{
 													speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 												},
 												Description: `Parsed as JSON.`,
-												Validators: []validator.String{
-													validators.IsValidJSON(),
-												},
 											},
 											"dlq": schema.SingleNestedAttribute{
 												Computed: true,
@@ -1980,15 +1953,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										},
 										Attributes: map[string]schema.Attribute{
 											"configuration": schema.StringAttribute{
-												Computed: true,
-												Optional: true,
+												CustomType: jsontypes.NormalizedType{},
+												Computed:   true,
+												Optional:   true,
 												PlanModifiers: []planmodifier.String{
 													speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 												},
 												Description: `Parsed as JSON.`,
-												Validators: []validator.String{
-													validators.IsValidJSON(),
-												},
 											},
 											"dlq": schema.SingleNestedAttribute{
 												Computed: true,
@@ -2099,15 +2070,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										},
 										Attributes: map[string]schema.Attribute{
 											"configuration": schema.StringAttribute{
-												Computed: true,
-												Optional: true,
+												CustomType: jsontypes.NormalizedType{},
+												Computed:   true,
+												Optional:   true,
 												PlanModifiers: []planmodifier.String{
 													speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 												},
 												Description: `Parsed as JSON.`,
-												Validators: []validator.String{
-													validators.IsValidJSON(),
-												},
 											},
 											"dlq": schema.SingleNestedAttribute{
 												Computed: true,
@@ -2642,15 +2611,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							},
 							Attributes: map[string]schema.Attribute{
 								"configuration": schema.StringAttribute{
-									Computed: true,
-									Optional: true,
+									CustomType: jsontypes.NormalizedType{},
+									Computed:   true,
+									Optional:   true,
 									PlanModifiers: []planmodifier.String{
 										speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 									},
 									Description: `Page source's configuration. Parsed as JSON.`,
-									Validators: []validator.String{
-										validators.IsValidJSON(),
-									},
 								},
 								"type": schema.StringAttribute{
 									Computed: true,
@@ -2923,15 +2890,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										},
 										Attributes: map[string]schema.Attribute{
 											"configuration": schema.StringAttribute{
-												Computed: true,
-												Optional: true,
+												CustomType: jsontypes.NormalizedType{},
+												Computed:   true,
+												Optional:   true,
 												PlanModifiers: []planmodifier.String{
 													speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 												},
 												Description: `Page source's configuration. Parsed as JSON.`,
-												Validators: []validator.String{
-													validators.IsValidJSON(),
-												},
 											},
 											"type": schema.StringAttribute{
 												Computed: true,
@@ -3124,15 +3089,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 													Description: `The condition of the step`,
 												},
 												"configuration": schema.StringAttribute{
-													Computed: true,
-													Optional: true,
+													CustomType: jsontypes.NormalizedType{},
+													Computed:   true,
+													Optional:   true,
 													PlanModifiers: []planmodifier.String{
 														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 													},
 													Description: `The configuration of the step. Parsed as JSON.`,
-													Validators: []validator.String{
-														validators.IsValidJSON(),
-													},
 												},
 												"description": schema.StringAttribute{
 													Computed: true,
@@ -3219,15 +3182,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 													Description: `The condition of the step`,
 												},
 												"configuration": schema.StringAttribute{
-													Computed: true,
-													Optional: true,
+													CustomType: jsontypes.NormalizedType{},
+													Computed:   true,
+													Optional:   true,
 													PlanModifiers: []planmodifier.String{
 														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 													},
 													Description: `The configuration of the step. Parsed as JSON.`,
-													Validators: []validator.String{
-														validators.IsValidJSON(),
-													},
 												},
 												"description": schema.StringAttribute{
 													Computed: true,
@@ -3305,15 +3266,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 													Description: `The condition of the step`,
 												},
 												"configuration": schema.StringAttribute{
-													Computed: true,
-													Optional: true,
+													CustomType: jsontypes.NormalizedType{},
+													Computed:   true,
+													Optional:   true,
 													PlanModifiers: []planmodifier.String{
 														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 													},
 													Description: `The configuration of the step. Parsed as JSON.`,
-													Validators: []validator.String{
-														validators.IsValidJSON(),
-													},
 												},
 												"description": schema.StringAttribute{
 													Computed: true,
@@ -3383,15 +3342,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 													Description: `The condition of the step`,
 												},
 												"configuration": schema.StringAttribute{
-													Computed: true,
-													Optional: true,
+													CustomType: jsontypes.NormalizedType{},
+													Computed:   true,
+													Optional:   true,
 													PlanModifiers: []planmodifier.String{
 														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 													},
 													Description: `The configuration of the step. Parsed as JSON.`,
-													Validators: []validator.String{
-														validators.IsValidJSON(),
-													},
 												},
 												"description": schema.StringAttribute{
 													Computed: true,
@@ -3461,15 +3418,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 													Description: `The condition of the step`,
 												},
 												"configuration": schema.StringAttribute{
-													Computed: true,
-													Optional: true,
+													CustomType: jsontypes.NormalizedType{},
+													Computed:   true,
+													Optional:   true,
 													PlanModifiers: []planmodifier.String{
 														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 													},
 													Description: `The configuration of the step. Parsed as JSON.`,
-													Validators: []validator.String{
-														validators.IsValidJSON(),
-													},
 												},
 												"description": schema.StringAttribute{
 													Computed: true,
@@ -3745,15 +3700,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 													Description: `The condition of the step`,
 												},
 												"configuration": schema.StringAttribute{
-													Computed: true,
-													Optional: true,
+													CustomType: jsontypes.NormalizedType{},
+													Computed:   true,
+													Optional:   true,
 													PlanModifiers: []planmodifier.String{
 														speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 													},
 													Description: `The configuration of the step. Parsed as JSON.`,
-													Validators: []validator.String{
-														validators.IsValidJSON(),
-													},
 												},
 												"description": schema.StringAttribute{
 													Computed: true,
@@ -3868,15 +3821,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							},
 							Attributes: map[string]schema.Attribute{
 								"configuration": schema.StringAttribute{
-									Computed: true,
-									Optional: true,
+									CustomType: jsontypes.NormalizedType{},
+									Computed:   true,
+									Optional:   true,
 									PlanModifiers: []planmodifier.String{
 										speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 									},
 									Description: `Parsed as JSON.`,
-									Validators: []validator.String{
-										validators.IsValidJSON(),
-									},
 								},
 								"type": schema.StringAttribute{
 									Computed: true,
@@ -4097,15 +4048,15 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 					},
 					Attributes: map[string]schema.Attribute{
 						"configuration": schema.StringAttribute{
-							Computed: true,
-							Optional: true,
+							CustomType: jsontypes.NormalizedType{},
+							Computed:   true,
+							Optional:   true,
 							PlanModifiers: []planmodifier.String{
 								speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 							},
 							Description: `Resource configuration. Not Null; Parsed as JSON.`,
 							Validators: []validator.String{
 								speakeasy_stringvalidators.NotNull(),
-								validators.IsValidJSON(),
 							},
 						},
 						"enabled": schema.BoolAttribute{
@@ -4176,15 +4127,13 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 						},
 						Attributes: map[string]schema.Attribute{
 							"configuration": schema.StringAttribute{
-								Computed: true,
-								Optional: true,
+								CustomType: jsontypes.NormalizedType{},
+								Computed:   true,
+								Optional:   true,
 								PlanModifiers: []planmodifier.String{
 									speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 								},
 								Description: `The configuration of the service. Parsed as JSON.`,
-								Validators: []validator.String{
-									validators.IsValidJSON(),
-								},
 							},
 							"enabled": schema.BoolAttribute{
 								Computed: true,

--- a/internal/provider/apiv4_resource_sdk.go
+++ b/internal/provider/apiv4_resource_sdk.go
@@ -9,6 +9,7 @@ import (
 	tfTypes "github.com/gravitee-io/terraform-provider-apim/internal/provider/types"
 	"github.com/gravitee-io/terraform-provider-apim/internal/sdk/models/operations"
 	"github.com/gravitee-io/terraform-provider-apim/internal/sdk/models/shared"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"time"
@@ -86,10 +87,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 				var endpoints tfTypes.EndpointV4
 
 				if endpointsItem.Configuration == nil {
-					endpoints.Configuration = types.StringNull()
+					endpoints.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult, _ := json.Marshal(endpointsItem.Configuration)
-					endpoints.Configuration = types.StringValue(string(configurationResult))
+					endpoints.Configuration = jsontypes.NewNormalizedValue(string(configurationResult))
 				}
 				endpoints.InheritConfiguration = types.BoolPointerValue(endpointsItem.InheritConfiguration)
 				endpoints.Name = types.StringPointerValue(endpointsItem.Name)
@@ -103,10 +104,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 					} else {
 						endpoints.Services.HealthCheck = &tfTypes.ServiceV4{}
 						if endpointsItem.Services.HealthCheck.Configuration == nil {
-							endpoints.Services.HealthCheck.Configuration = types.StringNull()
+							endpoints.Services.HealthCheck.Configuration = jsontypes.NewNormalizedNull()
 						} else {
 							configurationResult1, _ := json.Marshal(endpointsItem.Services.HealthCheck.Configuration)
-							endpoints.Services.HealthCheck.Configuration = types.StringValue(string(configurationResult1))
+							endpoints.Services.HealthCheck.Configuration = jsontypes.NewNormalizedValue(string(configurationResult1))
 						}
 						endpoints.Services.HealthCheck.Enabled = types.BoolPointerValue(endpointsItem.Services.HealthCheck.Enabled)
 						endpoints.Services.HealthCheck.OverrideConfiguration = types.BoolPointerValue(endpointsItem.Services.HealthCheck.OverrideConfiguration)
@@ -114,10 +115,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 					}
 				}
 				if endpointsItem.SharedConfigurationOverride == nil {
-					endpoints.SharedConfigurationOverride = types.StringNull()
+					endpoints.SharedConfigurationOverride = jsontypes.NewNormalizedNull()
 				} else {
 					sharedConfigurationOverrideResult, _ := json.Marshal(endpointsItem.SharedConfigurationOverride)
-					endpoints.SharedConfigurationOverride = types.StringValue(string(sharedConfigurationOverrideResult))
+					endpoints.SharedConfigurationOverride = jsontypes.NewNormalizedValue(string(sharedConfigurationOverrideResult))
 				}
 				endpoints.Tenants = make([]types.String, 0, len(endpointsItem.Tenants))
 				for _, v := range endpointsItem.Tenants {
@@ -148,10 +149,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 				} else {
 					endpointGroups.Services.Discovery = &tfTypes.ServiceV4{}
 					if endpointGroupsItem.Services.Discovery.Configuration == nil {
-						endpointGroups.Services.Discovery.Configuration = types.StringNull()
+						endpointGroups.Services.Discovery.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult2, _ := json.Marshal(endpointGroupsItem.Services.Discovery.Configuration)
-						endpointGroups.Services.Discovery.Configuration = types.StringValue(string(configurationResult2))
+						endpointGroups.Services.Discovery.Configuration = jsontypes.NewNormalizedValue(string(configurationResult2))
 					}
 					endpointGroups.Services.Discovery.Enabled = types.BoolPointerValue(endpointGroupsItem.Services.Discovery.Enabled)
 					endpointGroups.Services.Discovery.OverrideConfiguration = types.BoolPointerValue(endpointGroupsItem.Services.Discovery.OverrideConfiguration)
@@ -162,10 +163,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 				} else {
 					endpointGroups.Services.HealthCheck = &tfTypes.ServiceV4{}
 					if endpointGroupsItem.Services.HealthCheck.Configuration == nil {
-						endpointGroups.Services.HealthCheck.Configuration = types.StringNull()
+						endpointGroups.Services.HealthCheck.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult3, _ := json.Marshal(endpointGroupsItem.Services.HealthCheck.Configuration)
-						endpointGroups.Services.HealthCheck.Configuration = types.StringValue(string(configurationResult3))
+						endpointGroups.Services.HealthCheck.Configuration = jsontypes.NewNormalizedValue(string(configurationResult3))
 					}
 					endpointGroups.Services.HealthCheck.Enabled = types.BoolPointerValue(endpointGroupsItem.Services.HealthCheck.Enabled)
 					endpointGroups.Services.HealthCheck.OverrideConfiguration = types.BoolPointerValue(endpointGroupsItem.Services.HealthCheck.OverrideConfiguration)
@@ -173,10 +174,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 				}
 			}
 			if endpointGroupsItem.SharedConfiguration == nil {
-				endpointGroups.SharedConfiguration = types.StringNull()
+				endpointGroups.SharedConfiguration = jsontypes.NewNormalizedNull()
 			} else {
 				sharedConfigurationResult, _ := json.Marshal(endpointGroupsItem.SharedConfiguration)
-				endpointGroups.SharedConfiguration = types.StringValue(string(sharedConfigurationResult))
+				endpointGroups.SharedConfiguration = jsontypes.NewNormalizedValue(string(sharedConfigurationResult))
 			}
 			endpointGroups.Type = types.StringValue(endpointGroupsItem.Type)
 
@@ -216,10 +217,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 
 				connect.Condition = types.StringPointerValue(connectItem.Condition)
 				if connectItem.Configuration == nil {
-					connect.Configuration = types.StringNull()
+					connect.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult4, _ := json.Marshal(connectItem.Configuration)
-					connect.Configuration = types.StringValue(string(configurationResult4))
+					connect.Configuration = jsontypes.NewNormalizedValue(string(configurationResult4))
 				}
 				connect.Description = types.StringPointerValue(connectItem.Description)
 				connect.Enabled = types.BoolPointerValue(connectItem.Enabled)
@@ -238,10 +239,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 
 				interact.Condition = types.StringPointerValue(interactItem.Condition)
 				if interactItem.Configuration == nil {
-					interact.Configuration = types.StringNull()
+					interact.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult5, _ := json.Marshal(interactItem.Configuration)
-					interact.Configuration = types.StringValue(string(configurationResult5))
+					interact.Configuration = jsontypes.NewNormalizedValue(string(configurationResult5))
 				}
 				interact.Description = types.StringPointerValue(interactItem.Description)
 				interact.Enabled = types.BoolPointerValue(interactItem.Enabled)
@@ -259,10 +260,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 
 				publish.Condition = types.StringPointerValue(publishItem.Condition)
 				if publishItem.Configuration == nil {
-					publish.Configuration = types.StringNull()
+					publish.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult6, _ := json.Marshal(publishItem.Configuration)
-					publish.Configuration = types.StringValue(string(configurationResult6))
+					publish.Configuration = jsontypes.NewNormalizedValue(string(configurationResult6))
 				}
 				publish.Description = types.StringPointerValue(publishItem.Description)
 				publish.Enabled = types.BoolPointerValue(publishItem.Enabled)
@@ -279,10 +280,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 
 				request.Condition = types.StringPointerValue(requestItem.Condition)
 				if requestItem.Configuration == nil {
-					request.Configuration = types.StringNull()
+					request.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult7, _ := json.Marshal(requestItem.Configuration)
-					request.Configuration = types.StringValue(string(configurationResult7))
+					request.Configuration = jsontypes.NewNormalizedValue(string(configurationResult7))
 				}
 				request.Description = types.StringPointerValue(requestItem.Description)
 				request.Enabled = types.BoolPointerValue(requestItem.Enabled)
@@ -299,10 +300,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 
 				response.Condition = types.StringPointerValue(responseItem.Condition)
 				if responseItem.Configuration == nil {
-					response.Configuration = types.StringNull()
+					response.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult8, _ := json.Marshal(responseItem.Configuration)
-					response.Configuration = types.StringValue(string(configurationResult8))
+					response.Configuration = jsontypes.NewNormalizedValue(string(configurationResult8))
 				}
 				response.Description = types.StringPointerValue(responseItem.Description)
 				response.Enabled = types.BoolPointerValue(responseItem.Enabled)
@@ -364,10 +365,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 
 				subscribe.Condition = types.StringPointerValue(subscribeItem.Condition)
 				if subscribeItem.Configuration == nil {
-					subscribe.Configuration = types.StringNull()
+					subscribe.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult9, _ := json.Marshal(subscribeItem.Configuration)
-					subscribe.Configuration = types.StringValue(string(configurationResult9))
+					subscribe.Configuration = jsontypes.NewNormalizedValue(string(configurationResult9))
 				}
 				subscribe.Description = types.StringPointerValue(subscribeItem.Description)
 				subscribe.Enabled = types.BoolPointerValue(subscribeItem.Enabled)
@@ -433,10 +434,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 					var entrypoints tfTypes.Entrypoint
 
 					if entrypointsItem.Configuration == nil {
-						entrypoints.Configuration = types.StringNull()
+						entrypoints.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult10, _ := json.Marshal(entrypointsItem.Configuration)
-						entrypoints.Configuration = types.StringValue(string(configurationResult10))
+						entrypoints.Configuration = jsontypes.NewNormalizedValue(string(configurationResult10))
 					}
 					if entrypointsItem.Dlq == nil {
 						entrypoints.Dlq = nil
@@ -482,10 +483,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 					var entrypoints1 tfTypes.Entrypoint
 
 					if entrypointsItem1.Configuration == nil {
-						entrypoints1.Configuration = types.StringNull()
+						entrypoints1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult11, _ := json.Marshal(entrypointsItem1.Configuration)
-						entrypoints1.Configuration = types.StringValue(string(configurationResult11))
+						entrypoints1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult11))
 					}
 					if entrypointsItem1.Dlq == nil {
 						entrypoints1.Dlq = nil
@@ -518,10 +519,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 					var entrypoints2 tfTypes.Entrypoint
 
 					if entrypointsItem2.Configuration == nil {
-						entrypoints2.Configuration = types.StringNull()
+						entrypoints2.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult12, _ := json.Marshal(entrypointsItem2.Configuration)
-						entrypoints2.Configuration = types.StringValue(string(configurationResult12))
+						entrypoints2.Configuration = jsontypes.NewNormalizedValue(string(configurationResult12))
 					}
 					if entrypointsItem2.Dlq == nil {
 						entrypoints2.Dlq = nil
@@ -552,10 +553,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 					var entrypoints3 tfTypes.Entrypoint
 
 					if entrypointsItem3.Configuration == nil {
-						entrypoints3.Configuration = types.StringNull()
+						entrypoints3.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult13, _ := json.Marshal(entrypointsItem3.Configuration)
-						entrypoints3.Configuration = types.StringValue(string(configurationResult13))
+						entrypoints3.Configuration = jsontypes.NewNormalizedValue(string(configurationResult13))
 					}
 					if entrypointsItem3.Dlq == nil {
 						entrypoints3.Dlq = nil
@@ -675,10 +676,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 			} else {
 				pages.Source = &tfTypes.PageSource{}
 				if pagesItem.Source.Configuration == nil {
-					pages.Source.Configuration = types.StringNull()
+					pages.Source.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult14, _ := json.Marshal(pagesItem.Source.Configuration)
-					pages.Source.Configuration = types.StringValue(string(configurationResult14))
+					pages.Source.Configuration = jsontypes.NewNormalizedValue(string(configurationResult14))
 				}
 				pages.Source.Type = types.StringPointerValue(pagesItem.Source.Type)
 			}
@@ -746,10 +747,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 				} else {
 					translations.Source = &tfTypes.PageSource{}
 					if translationsItem.Source.Configuration == nil {
-						translations.Source.Configuration = types.StringNull()
+						translations.Source.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult15, _ := json.Marshal(translationsItem.Source.Configuration)
-						translations.Source.Configuration = types.StringValue(string(configurationResult15))
+						translations.Source.Configuration = jsontypes.NewNormalizedValue(string(configurationResult15))
 					}
 					translations.Source.Type = types.StringPointerValue(translationsItem.Source.Type)
 				}
@@ -799,10 +800,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 
 					connect1.Condition = types.StringPointerValue(connectItem1.Condition)
 					if connectItem1.Configuration == nil {
-						connect1.Configuration = types.StringNull()
+						connect1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult16, _ := json.Marshal(connectItem1.Configuration)
-						connect1.Configuration = types.StringValue(string(configurationResult16))
+						connect1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult16))
 					}
 					connect1.Description = types.StringPointerValue(connectItem1.Description)
 					connect1.Enabled = types.BoolPointerValue(connectItem1.Enabled)
@@ -821,10 +822,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 
 					interact1.Condition = types.StringPointerValue(interactItem1.Condition)
 					if interactItem1.Configuration == nil {
-						interact1.Configuration = types.StringNull()
+						interact1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult17, _ := json.Marshal(interactItem1.Configuration)
-						interact1.Configuration = types.StringValue(string(configurationResult17))
+						interact1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult17))
 					}
 					interact1.Description = types.StringPointerValue(interactItem1.Description)
 					interact1.Enabled = types.BoolPointerValue(interactItem1.Enabled)
@@ -842,10 +843,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 
 					publish1.Condition = types.StringPointerValue(publishItem1.Condition)
 					if publishItem1.Configuration == nil {
-						publish1.Configuration = types.StringNull()
+						publish1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult18, _ := json.Marshal(publishItem1.Configuration)
-						publish1.Configuration = types.StringValue(string(configurationResult18))
+						publish1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult18))
 					}
 					publish1.Description = types.StringPointerValue(publishItem1.Description)
 					publish1.Enabled = types.BoolPointerValue(publishItem1.Enabled)
@@ -862,10 +863,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 
 					request1.Condition = types.StringPointerValue(requestItem1.Condition)
 					if requestItem1.Configuration == nil {
-						request1.Configuration = types.StringNull()
+						request1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult19, _ := json.Marshal(requestItem1.Configuration)
-						request1.Configuration = types.StringValue(string(configurationResult19))
+						request1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult19))
 					}
 					request1.Description = types.StringPointerValue(requestItem1.Description)
 					request1.Enabled = types.BoolPointerValue(requestItem1.Enabled)
@@ -882,10 +883,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 
 					response1.Condition = types.StringPointerValue(responseItem1.Condition)
 					if responseItem1.Configuration == nil {
-						response1.Configuration = types.StringNull()
+						response1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult20, _ := json.Marshal(responseItem1.Configuration)
-						response1.Configuration = types.StringValue(string(configurationResult20))
+						response1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult20))
 					}
 					response1.Description = types.StringPointerValue(responseItem1.Description)
 					response1.Enabled = types.BoolPointerValue(responseItem1.Enabled)
@@ -947,10 +948,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 
 					subscribe1.Condition = types.StringPointerValue(subscribeItem1.Condition)
 					if subscribeItem1.Configuration == nil {
-						subscribe1.Configuration = types.StringNull()
+						subscribe1.Configuration = jsontypes.NewNormalizedNull()
 					} else {
 						configurationResult21, _ := json.Marshal(subscribeItem1.Configuration)
-						subscribe1.Configuration = types.StringValue(string(configurationResult21))
+						subscribe1.Configuration = jsontypes.NewNormalizedValue(string(configurationResult21))
 					}
 					subscribe1.Description = types.StringPointerValue(subscribeItem1.Description)
 					subscribe1.Enabled = types.BoolPointerValue(subscribeItem1.Enabled)
@@ -972,10 +973,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 			plans.Mode = types.StringValue(string(plansItem.Mode))
 			plans.Name = types.StringValue(plansItem.Name)
 			if plansItem.Security.Configuration == nil {
-				plans.Security.Configuration = types.StringNull()
+				plans.Security.Configuration = jsontypes.NewNormalizedNull()
 			} else {
 				configurationResult22, _ := json.Marshal(plansItem.Security.Configuration)
-				plans.Security.Configuration = types.StringValue(string(configurationResult22))
+				plans.Security.Configuration = jsontypes.NewNormalizedValue(string(configurationResult22))
 			}
 			plans.Security.Type = types.StringValue(string(plansItem.Security.Type))
 			plans.SelectionRule = types.StringPointerValue(plansItem.SelectionRule)
@@ -1022,7 +1023,7 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 			var resources tfTypes.Resource
 
 			configurationResult23, _ := json.Marshal(resourcesItem.Configuration)
-			resources.Configuration = types.StringValue(string(configurationResult23))
+			resources.Configuration = jsontypes.NewNormalizedValue(string(configurationResult23))
 			resources.Enabled = types.BoolPointerValue(resourcesItem.Enabled)
 			resources.Name = types.StringValue(resourcesItem.Name)
 			resources.Type = types.StringValue(resourcesItem.Type)
@@ -1063,10 +1064,10 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 			} else {
 				r.Services.DynamicProperty = &tfTypes.ServiceV4{}
 				if resp.Services.DynamicProperty.Configuration == nil {
-					r.Services.DynamicProperty.Configuration = types.StringNull()
+					r.Services.DynamicProperty.Configuration = jsontypes.NewNormalizedNull()
 				} else {
 					configurationResult24, _ := json.Marshal(resp.Services.DynamicProperty.Configuration)
-					r.Services.DynamicProperty.Configuration = types.StringValue(string(configurationResult24))
+					r.Services.DynamicProperty.Configuration = jsontypes.NewNormalizedValue(string(configurationResult24))
 				}
 				r.Services.DynamicProperty.Enabled = types.BoolPointerValue(resp.Services.DynamicProperty.Enabled)
 				r.Services.DynamicProperty.OverrideConfiguration = types.BoolPointerValue(resp.Services.DynamicProperty.OverrideConfiguration)

--- a/internal/provider/subscription_data_source.go
+++ b/internal/provider/subscription_data_source.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/gravitee-io/terraform-provider-apim/internal/sdk"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -37,15 +38,15 @@ type SubscriptionDataSource struct {
 
 // SubscriptionDataSourceModel describes the data model.
 type SubscriptionDataSourceModel struct {
-	APIHrid         types.String `tfsdk:"api_hrid"`
-	ApplicationHrid types.String `tfsdk:"application_hrid"`
-	EndingAt        types.String `tfsdk:"ending_at"`
-	EnvironmentID   types.String `tfsdk:"environment_id"`
-	Hrid            types.String `tfsdk:"hrid"`
-	ID              types.String `tfsdk:"id"`
-	OrganizationID  types.String `tfsdk:"organization_id"`
-	PlanHrid        types.String `tfsdk:"plan_hrid"`
-	StartingAt      types.String `tfsdk:"starting_at"`
+	APIHrid         types.String      `tfsdk:"api_hrid"`
+	ApplicationHrid types.String      `tfsdk:"application_hrid"`
+	EndingAt        timetypes.RFC3339 `tfsdk:"ending_at"`
+	EnvironmentID   types.String      `tfsdk:"environment_id"`
+	Hrid            types.String      `tfsdk:"hrid"`
+	ID              types.String      `tfsdk:"id"`
+	OrganizationID  types.String      `tfsdk:"organization_id"`
+	PlanHrid        types.String      `tfsdk:"plan_hrid"`
+	StartingAt      timetypes.RFC3339 `tfsdk:"starting_at"`
 }
 
 // Metadata returns the data source type name.
@@ -68,7 +69,8 @@ func (r *SubscriptionDataSource) Schema(ctx context.Context, req datasource.Sche
 				Description: `Application's Hrid that needs to subscribe to the API.`,
 			},
 			"ending_at": schema.StringAttribute{
-				Computed: true,
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
 			},
 			"environment_id": schema.StringAttribute{
 				Computed:    true,
@@ -96,7 +98,8 @@ func (r *SubscriptionDataSource) Schema(ctx context.Context, req datasource.Sche
 				Description: `API plan's Hrid`,
 			},
 			"starting_at": schema.StringAttribute{
-				Computed: true,
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
 			},
 		},
 	}

--- a/internal/provider/subscription_data_source_sdk.go
+++ b/internal/provider/subscription_data_source_sdk.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gravitee-io/terraform-provider-apim/internal/provider/typeconvert"
 	"github.com/gravitee-io/terraform-provider-apim/internal/sdk/models/operations"
 	"github.com/gravitee-io/terraform-provider-apim/internal/sdk/models/shared"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -17,11 +18,15 @@ func (r *SubscriptionDataSourceModel) RefreshFromSharedSubscriptionState(ctx con
 	if resp != nil {
 		r.APIHrid = types.StringValue(resp.APIHrid)
 		r.ApplicationHrid = types.StringValue(resp.ApplicationHrid)
-		r.EndingAt = types.StringPointerValue(typeconvert.TimePointerToStringPointer(resp.EndingAt))
+		endingAtValuable, endingAtDiags := timetypes.RFC3339Type{}.ValueFromString(ctx, types.StringPointerValue(typeconvert.TimePointerToStringPointer(resp.EndingAt)))
+		diags.Append(endingAtDiags...)
+		r.EndingAt = endingAtValuable.(timetypes.RFC3339)
 		r.Hrid = types.StringValue(resp.Hrid)
 		r.ID = types.StringPointerValue(resp.ID)
 		r.PlanHrid = types.StringValue(resp.PlanHrid)
-		r.StartingAt = types.StringPointerValue(typeconvert.TimePointerToStringPointer(resp.StartingAt))
+		startingAtValuable, startingAtDiags := timetypes.RFC3339Type{}.ValueFromString(ctx, types.StringPointerValue(typeconvert.TimePointerToStringPointer(resp.StartingAt)))
+		diags.Append(startingAtDiags...)
+		r.StartingAt = startingAtValuable.(timetypes.RFC3339)
 	}
 
 	return diags

--- a/internal/provider/subscription_resource.go
+++ b/internal/provider/subscription_resource.go
@@ -10,6 +10,7 @@ import (
 	speakeasy_stringplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/stringplanmodifier"
 	"github.com/gravitee-io/terraform-provider-apim/internal/sdk"
 	"github.com/gravitee-io/terraform-provider-apim/internal/validators"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -45,15 +46,15 @@ type SubscriptionResource struct {
 
 // SubscriptionResourceModel describes the resource data model.
 type SubscriptionResourceModel struct {
-	APIHrid         types.String `tfsdk:"api_hrid"`
-	ApplicationHrid types.String `tfsdk:"application_hrid"`
-	EndingAt        types.String `tfsdk:"ending_at"`
-	EnvironmentID   types.String `tfsdk:"environment_id"`
-	Hrid            types.String `tfsdk:"hrid"`
-	ID              types.String `tfsdk:"id"`
-	OrganizationID  types.String `tfsdk:"organization_id"`
-	PlanHrid        types.String `tfsdk:"plan_hrid"`
-	StartingAt      types.String `tfsdk:"starting_at"`
+	APIHrid         types.String      `tfsdk:"api_hrid"`
+	ApplicationHrid types.String      `tfsdk:"application_hrid"`
+	EndingAt        timetypes.RFC3339 `tfsdk:"ending_at"`
+	EnvironmentID   types.String      `tfsdk:"environment_id"`
+	Hrid            types.String      `tfsdk:"hrid"`
+	ID              types.String      `tfsdk:"id"`
+	OrganizationID  types.String      `tfsdk:"organization_id"`
+	PlanHrid        types.String      `tfsdk:"plan_hrid"`
+	StartingAt      timetypes.RFC3339 `tfsdk:"starting_at"`
 }
 
 func (r *SubscriptionResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -85,8 +86,9 @@ func (r *SubscriptionResource) Schema(ctx context.Context, req resource.SchemaRe
 				},
 			},
 			"ending_at": schema.StringAttribute{
-				Computed: true,
-				Optional: true,
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
+				Optional:   true,
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
@@ -132,7 +134,8 @@ func (r *SubscriptionResource) Schema(ctx context.Context, req resource.SchemaRe
 				Description: `API plan's Hrid`,
 			},
 			"starting_at": schema.StringAttribute{
-				Computed: true,
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},

--- a/internal/provider/subscription_resource_sdk.go
+++ b/internal/provider/subscription_resource_sdk.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gravitee-io/terraform-provider-apim/internal/provider/typeconvert"
 	"github.com/gravitee-io/terraform-provider-apim/internal/sdk/models/operations"
 	"github.com/gravitee-io/terraform-provider-apim/internal/sdk/models/shared"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"time"
@@ -18,11 +19,15 @@ func (r *SubscriptionResourceModel) RefreshFromSharedSubscriptionState(ctx conte
 	if resp != nil {
 		r.APIHrid = types.StringValue(resp.APIHrid)
 		r.ApplicationHrid = types.StringValue(resp.ApplicationHrid)
-		r.EndingAt = types.StringPointerValue(typeconvert.TimePointerToStringPointer(resp.EndingAt))
+		endingAtValuable, endingAtDiags := timetypes.RFC3339Type{}.ValueFromString(ctx, types.StringPointerValue(typeconvert.TimePointerToStringPointer(resp.EndingAt)))
+		diags.Append(endingAtDiags...)
+		r.EndingAt = endingAtValuable.(timetypes.RFC3339)
 		r.Hrid = types.StringValue(resp.Hrid)
 		r.ID = types.StringPointerValue(resp.ID)
 		r.PlanHrid = types.StringValue(resp.PlanHrid)
-		r.StartingAt = types.StringPointerValue(typeconvert.TimePointerToStringPointer(resp.StartingAt))
+		startingAtValuable, startingAtDiags := timetypes.RFC3339Type{}.ValueFromString(ctx, types.StringPointerValue(typeconvert.TimePointerToStringPointer(resp.StartingAt)))
+		diags.Append(startingAtDiags...)
+		r.StartingAt = startingAtValuable.(timetypes.RFC3339)
 	}
 
 	return diags

--- a/internal/provider/types/endpoint_group_v4.go
+++ b/internal/provider/types/endpoint_group_v4.go
@@ -3,6 +3,7 @@
 package types
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -11,6 +12,6 @@ type EndpointGroupV4 struct {
 	LoadBalancer        *LoadBalancer          `tfsdk:"load_balancer"`
 	Name                types.String           `tfsdk:"name"`
 	Services            *EndpointGroupServices `tfsdk:"services"`
-	SharedConfiguration types.String           `tfsdk:"shared_configuration"`
+	SharedConfiguration jsontypes.Normalized   `tfsdk:"shared_configuration"`
 	Type                types.String           `tfsdk:"type"`
 }

--- a/internal/provider/types/endpoint_v4.go
+++ b/internal/provider/types/endpoint_v4.go
@@ -3,17 +3,18 @@
 package types
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type EndpointV4 struct {
-	Configuration               types.String      `tfsdk:"configuration"`
-	InheritConfiguration        types.Bool        `tfsdk:"inherit_configuration"`
-	Name                        types.String      `tfsdk:"name"`
-	Secondary                   types.Bool        `tfsdk:"secondary"`
-	Services                    *EndpointServices `tfsdk:"services"`
-	SharedConfigurationOverride types.String      `tfsdk:"shared_configuration_override"`
-	Tenants                     []types.String    `tfsdk:"tenants"`
-	Type                        types.String      `tfsdk:"type"`
-	Weight                      types.Int32       `tfsdk:"weight"`
+	Configuration               jsontypes.Normalized `tfsdk:"configuration"`
+	InheritConfiguration        types.Bool           `tfsdk:"inherit_configuration"`
+	Name                        types.String         `tfsdk:"name"`
+	Secondary                   types.Bool           `tfsdk:"secondary"`
+	Services                    *EndpointServices    `tfsdk:"services"`
+	SharedConfigurationOverride jsontypes.Normalized `tfsdk:"shared_configuration_override"`
+	Tenants                     []types.String       `tfsdk:"tenants"`
+	Type                        types.String         `tfsdk:"type"`
+	Weight                      types.Int32          `tfsdk:"weight"`
 }

--- a/internal/provider/types/entrypoint.go
+++ b/internal/provider/types/entrypoint.go
@@ -3,12 +3,13 @@
 package types
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type Entrypoint struct {
-	Configuration types.String `tfsdk:"configuration"`
-	Dlq           *Dlq         `tfsdk:"dlq"`
-	Qos           types.String `tfsdk:"qos"`
-	Type          types.String `tfsdk:"type"`
+	Configuration jsontypes.Normalized `tfsdk:"configuration"`
+	Dlq           *Dlq                 `tfsdk:"dlq"`
+	Qos           types.String         `tfsdk:"qos"`
+	Type          types.String         `tfsdk:"type"`
 }

--- a/internal/provider/types/page_source.go
+++ b/internal/provider/types/page_source.go
@@ -3,10 +3,11 @@
 package types
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type PageSource struct {
-	Configuration types.String `tfsdk:"configuration"`
-	Type          types.String `tfsdk:"type"`
+	Configuration jsontypes.Normalized `tfsdk:"configuration"`
+	Type          types.String         `tfsdk:"type"`
 }

--- a/internal/provider/types/plan_security.go
+++ b/internal/provider/types/plan_security.go
@@ -3,10 +3,11 @@
 package types
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type PlanSecurity struct {
-	Configuration types.String `tfsdk:"configuration"`
-	Type          types.String `tfsdk:"type"`
+	Configuration jsontypes.Normalized `tfsdk:"configuration"`
+	Type          types.String         `tfsdk:"type"`
 }

--- a/internal/provider/types/resource.go
+++ b/internal/provider/types/resource.go
@@ -3,12 +3,13 @@
 package types
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type Resource struct {
-	Configuration types.String `tfsdk:"configuration"`
-	Enabled       types.Bool   `tfsdk:"enabled"`
-	Name          types.String `tfsdk:"name"`
-	Type          types.String `tfsdk:"type"`
+	Configuration jsontypes.Normalized `tfsdk:"configuration"`
+	Enabled       types.Bool           `tfsdk:"enabled"`
+	Name          types.String         `tfsdk:"name"`
+	Type          types.String         `tfsdk:"type"`
 }

--- a/internal/provider/types/service_v4.go
+++ b/internal/provider/types/service_v4.go
@@ -3,12 +3,13 @@
 package types
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type ServiceV4 struct {
-	Configuration         types.String `tfsdk:"configuration"`
-	Enabled               types.Bool   `tfsdk:"enabled"`
-	OverrideConfiguration types.Bool   `tfsdk:"override_configuration"`
-	Type                  types.String `tfsdk:"type"`
+	Configuration         jsontypes.Normalized `tfsdk:"configuration"`
+	Enabled               types.Bool           `tfsdk:"enabled"`
+	OverrideConfiguration types.Bool           `tfsdk:"override_configuration"`
+	Type                  types.String         `tfsdk:"type"`
 }

--- a/internal/provider/types/step_v4.go
+++ b/internal/provider/types/step_v4.go
@@ -3,15 +3,16 @@
 package types
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type StepV4 struct {
-	Condition        types.String `tfsdk:"condition"`
-	Configuration    types.String `tfsdk:"configuration"`
-	Description      types.String `tfsdk:"description"`
-	Enabled          types.Bool   `tfsdk:"enabled"`
-	MessageCondition types.String `tfsdk:"message_condition"`
-	Name             types.String `tfsdk:"name"`
-	Policy           types.String `tfsdk:"policy"`
+	Condition        types.String         `tfsdk:"condition"`
+	Configuration    jsontypes.Normalized `tfsdk:"configuration"`
+	Description      types.String         `tfsdk:"description"`
+	Enabled          types.Bool           `tfsdk:"enabled"`
+	MessageCondition types.String         `tfsdk:"message_condition"`
+	Name             types.String         `tfsdk:"name"`
+	Policy           types.String         `tfsdk:"policy"`
 }

--- a/internal/sdk/graviteeapim.go
+++ b/internal/sdk/graviteeapim.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 1.0.0 and generator version 2.675.0
+// Generated from OpenAPI doc version 1.0.0 and generator version 2.683.1
 
 import (
 	"context"
@@ -158,7 +158,7 @@ func New(opts ...SDKOption) *GraviteeApim {
 	sdk := &GraviteeApim{
 		SDKVersion: "0.3.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.3.0 2.675.0 1.0.0 github.com/gravitee-io/terraform-provider-apim/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.3.0 2.683.1 1.0.0 github.com/gravitee-io/terraform-provider-apim/internal/sdk",
 			Globals:    globals.Globals{},
 			ServerList: ServerList,
 		},

--- a/internal/sdk/internal/utils/retries.go
+++ b/internal/sdk/internal/utils/retries.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -27,6 +28,17 @@ type Retries struct {
 	Config      *retry.Config
 	StatusCodes []string
 }
+
+var (
+	// IETF RFC 7231 4.2 safe and idempotent HTTP methods for connection retries
+	idempotentHTTPMethods = []string{
+		http.MethodDelete,
+		http.MethodGet,
+		http.MethodHead,
+		http.MethodOptions,
+		http.MethodPut,
+	}
+)
 
 func Retry(ctx context.Context, r Retries, operation func() (*http.Response, error)) (*http.Response, error) {
 	switch r.Config.Strategy {
@@ -50,11 +62,48 @@ func Retry(ctx context.Context, r Retries, operation func() (*http.Response, err
 
 			res, err := operation()
 			if err != nil {
+				if !r.Config.RetryConnectionErrors {
+					return retry.Permanent(err)
+				}
+
+				var httpMethod string
+
+				// Use http.Request method if available
+				if res != nil && res.Request != nil {
+					httpMethod = res.Request.Method
+				}
+
+				isIdempotentHTTPMethod := slices.Contains(idempotentHTTPMethods, httpMethod)
 				urlError := new(url.Error)
+
 				if errors.As(err, &urlError) {
-					if (urlError.Temporary() || urlError.Timeout() || errors.Is(urlError.Err, io.EOF)) && r.Config.RetryConnectionErrors {
+					if urlError.Temporary() || urlError.Timeout() {
 						return err
 					}
+
+					// In certain error cases, the http.Request may not have
+					// been populated, so use url.Error.Op which only has its
+					// first character capitalized from the original request
+					// HTTP method.
+					if httpMethod == "" {
+						httpMethod = strings.ToUpper(urlError.Op)
+					}
+
+					isIdempotentHTTPMethod = slices.Contains(idempotentHTTPMethods, httpMethod)
+
+					// Connection closed
+					if errors.Is(urlError.Err, io.EOF) && isIdempotentHTTPMethod {
+						return err
+					}
+				}
+
+				// syscall detection is not available on every platform, so
+				// fallback to best effort string detection.
+				isBrokenPipeError := strings.Contains(err.Error(), "broken pipe")
+				isConnectionResetError := strings.Contains(err.Error(), "connection reset")
+
+				if (isBrokenPipeError || isConnectionResetError) && isIdempotentHTTPMethod {
+					return err
 				}
 
 				return retry.Permanent(err)

--- a/schemas/output/computed.yaml
+++ b/schemas/output/computed.yaml
@@ -820,6 +820,11 @@ components:
           type: string
           format: date-time
           example: "2040-12-25T09:12:28Z"
+          x-speakeasy-terraform-custom-type:
+            imports:
+              - github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes
+            schemaType: "timetypes.RFC3339Type{}"
+            valueType: timetypes.RFC3339
       required:
         - hrid
         - applicationHrid
@@ -843,6 +848,11 @@ components:
               type: string
               format: date-time
               example: "2040-12-25T09:12:28+01:00"
+              x-speakeasy-terraform-custom-type:
+                imports:
+                  - github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes
+                schemaType: "timetypes.RFC3339Type{}"
+                valueType: timetypes.RFC3339
           x-speakeasy-param-suppress-computed-diff: true
     SharedPolicyGroupState:
       description: State of Shared Policy Groups that has been created/updated

--- a/schemas/overlays/subscription.yaml
+++ b/schemas/overlays/subscription.yaml
@@ -40,3 +40,21 @@ actions:
     description: Not returned by the API, so prevent null values during refresh
     update:
       x-speakeasy-param-suppress-computed-diff: true
+
+# Custom types
+  - target: $.components.schemas.SubscriptionState.allOf[?@.properties.startingAt].properties.startingAt
+    description: x
+    update:
+      x-speakeasy-terraform-custom-type:
+        imports:
+          - github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes
+        schemaType: "timetypes.RFC3339Type{}"
+        valueType: timetypes.RFC3339
+  - target: $.components.schemas.SubscriptionSpec.properties.endingAt
+    description: x
+    update:
+      x-speakeasy-terraform-custom-type:
+        imports:
+          - github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes
+        schemaType: "timetypes.RFC3339Type{}"
+        valueType: timetypes.RFC3339

--- a/tests/acceptance/subscription_resource_test.go
+++ b/tests/acceptance/subscription_resource_test.go
@@ -126,6 +126,16 @@ func TestSubscriptionResource_update(t *testing.T) {
 					"organization_id": config.StringVariable(organizationId),
 				},
 			},
+			// Verifies resource update using an ending_at in a different format.
+			{
+				ConfigDirectory: config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"environment_id":  config.StringVariable(environmentId),
+					"hrid":            config.StringVariable(randomId),
+					"ending_at":       config.StringVariable("2043-12-25T10:12:28+00:00"),
+					"organization_id": config.StringVariable(organizationId),
+				},
+			},
 			// Testing framework implicitly verifies resource delete.
 		},
 	})


### PR DESCRIPTION
This PR uses a custom type for the subscription fields `startingAt` and `endingAt`.

The custom field uses type [RFC3339](https://github.com/hashicorp/terraform-plugin-framework-timetypes/blob/main/timetypes/rfc3339_type.go) from the Terraform package `github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes` package.

Before this change, `startingAt` and `endingAt` were strings, so if you use a timezone in the Terraform file, the resource will look as out of date after creation.

For example, if `ending_at` is set to `2042-12-25T10:12:28+00:00` and the object is applied, a `terraform plan` will show that the field is out of date, because the server returns `2042-12-25T10:12:28Z`.

Note that the Terraform library uses [semantic comparisons](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework-timetypes@v0.5.0/timetypes#RFC3339), which means that `2023-07-25T20:00:00+00:00` is equal to `2023-07-25T20:00:00Z` but not to `2023-07-25T21:00:00+01:00`.

This should be relatively simple to fix once we decide if this behaviour is wanted. I think it is, but I'd like to get feedback before making a decision.  Some additional context about semantic comparisons can be found [here](https://discuss.hashicorp.com/t/semantic-equality-setattribute-and-configuration-changes/72269/3).

Notes:
- This PR should be merged after https://github.com/gravitee-io/terraform-provider-apim/pull/10. Once that's merged, this can be rebased, and tests should pass.
- Speaskeasy generated a bunch of code unrelated to my changes. I think these differences are caused by my version being more recent.  Since tests are passing, I'm assuming those changes are fine.