### PR TITLE
chore: Fix tests that's reusing a certificate

### DIFF
--- a/tests/acceptance/application_resource_test.go
+++ b/tests/acceptance/application_resource_test.go
@@ -1,8 +1,20 @@
 package acceptance_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -60,6 +72,111 @@ func TestApplicationResource_minimal(t *testing.T) {
 	})
 }
 
+func getPrivateKey(t *testing.T) *rsa.PrivateKey {
+	const pemPrivateKey = `
+-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQCxoeCUW5KJxNPxMp+KmCxKLc1Zv9Ny+4CFqcUXVUYH69L3mQ7v
+IWrJ9GBfcaA7BPQqUlWxWM+OCEQZH1EZNIuqRMNQVuIGCbz5UQ8w6tS0gcgdeGX7
+J7jgCQ4RK3F/PuCM38QBLaHx988qG8NMc6VKErBjctCXFHQt14lerd5KpQIDAQAB
+AoGAYrf6Hbk+mT5AI33k2Jt1kcweodBP7UkExkPxeuQzRVe0KVJw0EkcFhywKpr1
+V5eLMrILWcJnpyHE5slWwtFHBG6a5fLaNtsBBtcAIfqTQ0Vfj5c6SzVaJv0Z5rOd
+7gQF6isy3t3w9IF3We9wXQKzT6q5ypPGdm6fciKQ8RnzREkCQQDZwppKATqQ41/R
+vhSj90fFifrGE6aVKC1hgSpxGQa4oIdsYYHwMzyhBmWW9Xv/R+fPyr8ZwPxp2c12
+33QwOLPLAkEA0NNUb+z4ebVVHyvSwF5jhfJxigim+s49KuzJ1+A2RaSApGyBZiwS
+rWvWkB471POAKUYt5ykIWVZ83zcceQiNTwJBAMJUFQZX5GDqWFc/zwGoKkeR49Yi
+MTXIvf7Wmv6E++eFcnT461FlGAUHRV+bQQXGsItR/opIG7mGogIkVXa3E1MCQARX
+AAA7eoZ9AEHflUeuLn9QJI/r0hyQQLEtrpwv6rDT1GCWaLII5HJ6NUFVf4TTcqxo
+6vdM4QGKTJoO+SaCyP0CQFdpcxSAuzpFcKv0IlJ8XzS/cy+mweCMwyJ1PFEc4FX6
+wg/HcAJWY60xZTJDFN+Qfx8ZQvBEin6c2/h+zZi5IVY=
+-----END RSA PRIVATE KEY-----
+`
+	block, _ := pem.Decode([]byte(pemPrivateKey))
+
+	testPrivateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse private key: %s", err)
+	}
+
+	return testPrivateKey
+}
+
+func mustParseURI(t *testing.T, s string) *url.URL {
+	uri, err := url.Parse(s)
+	if err != nil {
+		t.Fatalf("Failed to parse URI %q: %s", s, err)
+	}
+	return uri
+}
+
+func mustNewOIDFromInts(t *testing.T, ints []uint64) x509.OID {
+	oid, err := x509.OIDFromInts(ints)
+	if err != nil {
+		t.Fatalf("OIDFromInts(%v) unexpected error: %v", ints, err)
+	}
+	return oid
+}
+
+func mustParseCIDR(t *testing.T, s string) *net.IPNet {
+	_, net, err := net.ParseCIDR(s)
+	if err != nil {
+		t.Fatalf("Failed to parse CIDR %q: %s", s, err)
+	}
+	return net
+}
+
+func getClientTLSCert(t *testing.T) string {
+	random := rand.Reader
+
+	ecdsaPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate ECDSA key: %s", err)
+	}
+
+	pub := &ecdsaPriv.PublicKey
+	priv := getPrivateKey(t)
+	sigAlgo := x509.SHA256WithRSA
+
+	commonName := "test.example.com"
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName:   commonName,
+			Organization: []string{"Gravitee"},
+			Country:      []string{"FR"},
+		},
+		NotBefore: time.Now().Add(-24 * time.Hour),
+		NotAfter:  time.Now().Add(24 * time.Hour),
+
+		SignatureAlgorithm: sigAlgo,
+
+		SubjectKeyId: []byte{1, 2, 3, 4},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+
+		OCSPServer:            []string{"http://ocsp.example.com"},
+		IssuingCertificateURL: []string{"http://crt.example.com/ca1.crt"},
+	}
+
+	derBytes, err := x509.CreateCertificate(random, &template, &template, pub, priv)
+	if err != nil {
+		t.Errorf("failed to create certificate: %s", err)
+	}
+
+	certData := strings.Builder{}
+	block := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: derBytes,
+	}
+
+	if err := pem.Encode(&certData, block); err != nil {
+		t.Fatalf("failed to encode certificate: %s", err)
+	}
+
+	return strings.TrimSpace(certData.String())
+}
+
 // Verifies the create, read, import, and delete lifecycle of the
 // `apim_application` resource with as many fields as possible
 func TestApplicationResource_all(t *testing.T) {
@@ -68,7 +185,7 @@ func TestApplicationResource_all(t *testing.T) {
 	environmentId := "DEFAULT"
 	organizationId := "DEFAULT"
 	randomId := "test-" + acctest.RandString(10)
-	resourceAddress := "apim_application.test"
+	cert := getClientTLSCert(t)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testProviders(),
@@ -77,37 +194,12 @@ func TestApplicationResource_all(t *testing.T) {
 			{
 				ConfigDirectory: config.TestNameDirectory(),
 				ConfigVariables: config.Variables{
-					"environment_id":  config.StringVariable(environmentId),
-					"hrid":            config.StringVariable(randomId),
-					"organization_id": config.StringVariable(organizationId),
+					"environment_id":     config.StringVariable(environmentId),
+					"hrid":               config.StringVariable(randomId),
+					"organization_id":    config.StringVariable(organizationId),
+					"client_certificate": config.StringVariable(cert),
 				},
 			},
-			// Verifies resource import.
-			{
-				ConfigDirectory: config.TestNameDirectory(),
-				ConfigVariables: config.Variables{
-					"environment_id":  config.StringVariable(environmentId),
-					"hrid":            config.StringVariable(randomId),
-					"organization_id": config.StringVariable(organizationId),
-				},
-				ResourceName: resourceAddress,
-				ImportState:  true,
-				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					importIDBytes, err := json.Marshal(struct {
-						EnvironmentId  string `json:"environment_id"`
-						Hrid           string `json:"hrid"`
-						OrganizationId string `json:"organization_id"`
-					}{
-						EnvironmentId:  s.RootModule().Resources[resourceAddress].Primary.Attributes["environment_id"],
-						Hrid:           s.RootModule().Resources[resourceAddress].Primary.Attributes["hrid"],
-						OrganizationId: s.RootModule().Resources[resourceAddress].Primary.Attributes["organization_id"],
-					})
-
-					return string(importIDBytes), err
-				},
-				ImportStateVerify: true,
-			},
-			// Testing framework implicitly verifies resource delete.
 		},
 	})
 }

--- a/tests/acceptance/testdata/TestApplicationResource_all/main.tf
+++ b/tests/acceptance/testdata/TestApplicationResource_all/main.tf
@@ -10,6 +10,10 @@ variable "environment_id" {
   type = string
 }
 
+variable "client_certificate" {
+  type = string
+}
+
 resource "apim_application" "test" {
   hrid            = var.hrid
   environment_id  = var.environment_id
@@ -33,7 +37,7 @@ resource "apim_application" "test" {
       type      = "backend to backend"
     }
     tls = {
-      client_certificate = "-----BEGIN CERTIFICATE-----\nMIIDfjCCAmagAwIBAgIUfHj3mygGaOfd1u1Uj09L6vY5stcwDQYJKoZIhvcNAQEL\nBQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM\nGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yNTA4MDUxNTUyMTBaFw0yNjA4\nMDUxNTUyMTBaMGkxCzAJBgNVBAYTAlVTMQ4wDAYDVQQIDAVTdGF0ZTENMAsGA1UE\nBwwEQ2l0eTEVMBMGA1UECgwMT3JnYW5pemF0aW9uMRMwEQYDVQQLDApEZXBhcnRt\nZW50MQ8wDQYDVQQDDAZjbGllbnQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK\nAoIBAQDW862KHvjkq0EtwZJO/xw+QoTnRB0qm4E5+1wspC1er6tOm3hTJqCzfKwQ\ngZQKoP1Eq1PhM8GzceeqGjh8VZJaDmWwiJZdk5fprrZ1Lvwwl010lnh4MEhtN0Dw\nlwHSZCQ/vSvEDWJXugiE4F1OvAgi2+lIR5uYfyy2U6YbhlcVPdGAboBAFSQnxECF\n1gDpc3dFarPXfO/X3yf/BzAHys6IyMyqvBbur3K2UTO4gJL+59/DEyAwx7ofwukj\nTWpgGNDXlNFYwKk9qTSTbxdcofAVCjrBCEDTdoPkvrr5SxI7dV/ha5y33iOI4VPV\no6vN/58RJz+ZMI0mbOBeluqBW+xBAgMBAAGjQjBAMB0GA1UdDgQWBBTjpQ+KfcmK\nw4hCptY8iK/LX9BOhzAfBgNVHSMEGDAWgBQYdcUWurMS8FEEMzcJlFm2d4Dk3DAN\nBgkqhkiG9w0BAQsFAAOCAQEAoyv0RhgEbRNmyFF6WoTeH4durjmZRe3SCtum0Mnv\n4TOGT4sstPdz0l24psroL33z3jtsY8IrbqnSfTXWbziSCanDXnMHOewLykgN0ld0\nPHa2i5naU5tMeGdWeM80ZTXU7GMiiCkgrRai/V7GkXNKYTIdBontiLpbxUaGLpjY\naMYoCmHIEizazQP9xaAtm40CkYub1o40kgyQULyrwftqrlRtKshfYmHB6yxYVz60\npikgTVupVbhYcNMLOVXO7Q31UEYfC7fxMGqzybXg67EhvzoykXhhYo3YqAjho2yh\num2oEO8b5eQVAwRaooVLh0uqjZCpfN2ozscPpiTM9Pj3xQ==\n-----END CERTIFICATE-----"
+      client_certificate = var.client_certificate
     }
   }
   metadata = [


### PR DESCRIPTION
Updated test `TestApplicationResource_all` that fails if a previous run doesn't delete the test resource.  This happens because a certificate can't be reused.


To fix the issue I generate a new certificate for every execution.