### PR TITLE
fix: remove API_KEY from plans

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: b5451c3d-2473-444c-bd62-9bf8987cd90b
 management:
-  docChecksum: d87fc47df99b82cc4e168a86f1a63021
+  docChecksum: e8318543603c4c534f317ce2cae48a1f
   docVersion: 1.0.0
   speakeasyVersion: 1.615.2
   generationVersion: 2.698.4

--- a/docs/resources/apiv4.md
+++ b/docs/resources/apiv4.md
@@ -955,7 +955,7 @@ Optional:
 Optional:
 
 - `configuration` (String) Parsed as JSON.
-- `type` (String) Plan security type. Not Null; must be one of ["KEY_LESS", "API_KEY", "OAUTH2", "JWT", "MTLS"]
+- `type` (String) Plan security type. Not Null; must be one of ["KEY_LESS", "OAUTH2", "JWT", "MTLS"]
 
 
 

--- a/internal/provider/apiv4_resource.go
+++ b/internal/provider/apiv4_resource.go
@@ -3833,12 +3833,11 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 									PlanModifiers: []planmodifier.String{
 										speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 									},
-									Description: `Plan security type. Not Null; must be one of ["KEY_LESS", "API_KEY", "OAUTH2", "JWT", "MTLS"]`,
+									Description: `Plan security type. Not Null; must be one of ["KEY_LESS", "OAUTH2", "JWT", "MTLS"]`,
 									Validators: []validator.String{
 										speakeasy_stringvalidators.NotNull(),
 										stringvalidator.OneOf(
 											"KEY_LESS",
-											"API_KEY",
 											"OAUTH2",
 											"JWT",
 											"MTLS",

--- a/internal/sdk/models/shared/plansecuritytype.go
+++ b/internal/sdk/models/shared/plansecuritytype.go
@@ -12,7 +12,6 @@ type PlanSecurityType string
 
 const (
 	PlanSecurityTypeKeyLess PlanSecurityType = "KEY_LESS"
-	PlanSecurityTypeAPIKey  PlanSecurityType = "API_KEY"
 	PlanSecurityTypeOauth2  PlanSecurityType = "OAUTH2"
 	PlanSecurityTypeJwt     PlanSecurityType = "JWT"
 	PlanSecurityTypeMtls    PlanSecurityType = "MTLS"
@@ -28,8 +27,6 @@ func (e *PlanSecurityType) UnmarshalJSON(data []byte) error {
 	}
 	switch v {
 	case "KEY_LESS":
-		fallthrough
-	case "API_KEY":
 		fallthrough
 	case "OAUTH2":
 		fallthrough

--- a/schemas/automation-api-oas.yaml
+++ b/schemas/automation-api-oas.yaml
@@ -1773,7 +1773,6 @@ components:
         - KEY_LESS
       enum:
         - KEY_LESS
-        - API_KEY
         - OAUTH2
         - JWT
         - MTLS

--- a/schemas/output/computed.yaml
+++ b/schemas/output/computed.yaml
@@ -1775,7 +1775,6 @@ components:
         - KEY_LESS
       enum:
         - KEY_LESS
-        - API_KEY
         - OAUTH2
         - JWT
         - MTLS

--- a/schemas/overlays/apiv4.yaml
+++ b/schemas/overlays/apiv4.yaml
@@ -194,6 +194,20 @@ actions:
     update:
       type: string
 
+  ## Enum change
+  - target: $.components.schemas.PlanSecurityType.enum
+    description: Remove API_KEY from the literal
+    remove: true
+  - target: $.components.schemas.PlanSecurityType
+    description: Remove API_KEY from the literal
+    update:
+      enum:
+        - KEY_LESS
+        - OAUTH2
+        - JWT
+        - MTLS
+
+
   ## SDK Ignored
   - target: $.components.schemas.PortalNotificationConfig
     description: Remove unsupported feature as not returned by the API

--- a/tests/acceptance/apiv4_resource_test.go
+++ b/tests/acceptance/apiv4_resource_test.go
@@ -2,6 +2,7 @@ package acceptance_test
 
 import (
 	"encoding/json"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
@@ -134,4 +135,30 @@ func TestAPIV4Resource_name(t *testing.T) {
 			// Testing framework implicitly verifies resource delete.
 		},
 	})
+}
+
+func TestAPIV4Resource_apikey(t *testing.T) {
+	t.Parallel()
+
+	environmentId := "DEFAULT"
+	organizationId := "DEFAULT"
+	randomId := "test-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			// Verifies resource create and read.
+			{
+				ProtoV6ProviderFactories: testProviders(),
+				ConfigDirectory:          config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"environment_id":  config.StringVariable(environmentId),
+					"hrid":            config.StringVariable(randomId),
+					"name":            config.StringVariable(randomId + "-original"),
+					"organization_id": config.StringVariable(organizationId),
+				},
+				ExpectError: regexp.MustCompile("got: \"API_KEY\""),
+			},
+		},
+	})
+
 }

--- a/tests/acceptance/testdata/TestAPIV4Resource_apikey/main.tf
+++ b/tests/acceptance/testdata/TestAPIV4Resource_apikey/main.tf
@@ -1,0 +1,81 @@
+variable "environment_id" {
+  type = string
+}
+
+variable "hrid" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "organization_id" {
+  type = string
+}
+
+resource "apim_apiv4" "test" {
+  environment_id  = var.environment_id
+  hrid            = var.hrid
+  lifecycle_state = "UNPUBLISHED"
+  name            = var.name
+  organization_id = var.organization_id
+  state           = "STOPPED"
+  type            = "PROXY"
+  version         = "1"
+  visibility      = "PRIVATE"
+
+  endpoint_groups = [
+    {
+      name = "Default HTTP proxy group"
+      type = "http-proxy"
+      load_balancer = {
+        type = "ROUND_ROBIN"
+      }
+      endpoints = [
+        {
+          name   = "Default HTTP proxy"
+          type   = "http-proxy"
+          weight = 1
+          configuration = jsonencode({
+            target = "https://example.com"
+          })
+        }
+      ]
+    }
+  ]
+
+  listeners = [
+    {
+      http = {
+
+        entrypoints = [
+          {
+            type = "http-proxy"
+          }
+        ]
+        paths = [
+          {
+            path = "/${var.hrid}/"
+          }
+        ]
+        type = "HTTP"
+      }
+    }
+  ]
+
+  plans = [
+    {
+      hrid        = "apikey"
+      description = "API Key"
+      mode        = "STANDARD"
+      name        = "Api Key"
+      status      = "PUBLISHED"
+      type        = "API"
+      validation  = "AUTO"
+      security = {
+        type = "API_KEY"
+      }
+    }
+  ]
+}

--- a/tests/examples/example_usecases_test.go
+++ b/tests/examples/example_usecases_test.go
@@ -41,9 +41,6 @@ func TestApplicationResource_Examples(t *testing.T) {
 
 	cleanupTerraformStateFiles(directories)
 
-	environmentId := "DEFAULT"
-	organizationId := "DEFAULT"
-
 	providers := testProviders()
 
 	for _, tc := range cases {
@@ -92,10 +89,8 @@ func TestApplicationResource_Examples(t *testing.T) {
 						ProtoV6ProviderFactories: providers,
 						ConfigDirectory:          tc.directory.get,
 						ConfigVariables: config.Variables{
-							"environment_id":  config.StringVariable(environmentId),
-							"hrid":            config.StringVariable(tc.hrid),
-							tc.updateField:    config.StringVariable(tc.updateValue),
-							"organization_id": config.StringVariable(organizationId),
+							"hrid":         config.StringVariable(tc.hrid),
+							tc.updateField: config.StringVariable(tc.updateValue),
 						},
 					},
 				},


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1516

## Description

Remove API_KEY from plan security for consistency with GKO and avoid bugs in automation API that will be fixed later when we have a plan for those across all of our tooling.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

