### PR TITLE
GKO-1513 - Run acceptance tests in parallel

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -45,7 +45,6 @@ jobs:
       contents: "read"
     strategy:
       fail-fast: false
-      max-parallel: 1
       matrix:
         terraform-version:
           - "1.10.*"
@@ -63,6 +62,6 @@ jobs:
           terraform_version: ${{ matrix.terraform-version }}
       - name: Run Acceptance & Example using ${{ env.APIM_SERVER_URL }}
         env:
-          APIM_USERNAME: ${{ secrets.TEST_USER }}
-          APIM_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
+          APIM_USERNAME: ${{ vars.APIM_ADMIN_USERNAME }}
+          APIM_PASSWORD: ${{ secrets.APIM_ADMIN_PASSWORD }}
         run: make acceptance-tests examples-tests

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -6,6 +6,9 @@ on:
     branches-ignore:
       - master
 
+env:
+  APIM_SERVER_URL: ${{ vars.TEST_SERVER_URL_MASTER }}
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -58,9 +61,8 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           terraform_version: ${{ matrix.terraform-version }}
-      - name: Run Acceptance & Example using ${{ vars.TEST_SERVER_URL_MASTER }}
+      - name: Run Acceptance & Example using ${{ env.APIM_SERVER_URL }}
         env:
-          APIM_SERVER_URL: ${{ vars.TEST_SERVER_URL_MASTER }}
           APIM_USERNAME: ${{ secrets.TEST_USER }}
           APIM_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
         run: make acceptance-tests examples-tests

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -36,6 +36,27 @@ jobs:
           APIM_API1_USERNAME: ${{ secrets.TEST_USER2 }}
           APIM_API1_PASSWORD: ${{ secrets.TEST_USER2_PASSWORD }}
         run: make pre-test
+  examples:
+    name: Run Terraform examples
+    runs-on: ubuntu-latest
+    needs:
+      - pre-test-validation
+    permissions:
+      contents: "read"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup go
+        uses: ./.github/actions/setup-go
+      - name: Setup terraform
+        uses: ./.github/actions/setup-terraform
+        with:
+          terraform_version: "1.12.*"
+      - name: Run example using ${{ env.APIM_SERVER_URL }}
+        env:
+          APIM_USERNAME: "${{ vars.APIM_ADMIN_USERNAME }}"
+          APIM_PASSWORD: "${{ secrets.APIM_ADMIN_PASSWORD }}"
+        run: make examples-tests
   acceptance:
     name: Acceptance Tests (Terraform ${{ matrix.terraform-version }})
     runs-on: ubuntu-latest
@@ -60,8 +81,8 @@ jobs:
         uses: ./.github/actions/setup-terraform
         with:
           terraform_version: ${{ matrix.terraform-version }}
-      - name: Run Acceptance & Example using ${{ env.APIM_SERVER_URL }}
+      - name: Run acceptance tests using ${{ env.APIM_SERVER_URL }}
         env:
           APIM_USERNAME: ${{ vars.APIM_ADMIN_USERNAME }}
           APIM_PASSWORD: ${{ secrets.APIM_ADMIN_PASSWORD }}
-        run: make acceptance-tests examples-tests
+        run: make acceptance-tests

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,12 @@ pre-test:
 
 .PHONY: acceptance-tests
 acceptance-tests: ## Run acceptance tests
-	@APIM_USERNAME=${APIM_USERNAME} APIM_PASSWORD=${APIM_PASSWORD} APIM_SERVER_URL=${APIM_SERVER_URL} TF_ACC=1 go test -v ./tests/acceptance
+	@APIM_USERNAME=${APIM_USERNAME} APIM_PASSWORD="$${APIM_PASSWORD}" APIM_SERVER_URL=${APIM_SERVER_URL} TF_ACC=1 go test -v ./tests/acceptance
 
 
 .PHONY: examples-tests
 examples-tests: ## Run acceptance tests using examples
-	@APIM_USERNAME=${APIM_USERNAME} APIM_PASSWORD=${APIM_PASSWORD} APIM_SERVER_URL=${APIM_SERVER_URL} TF_ACC=1 go test -v ./tests/examples
+	@APIM_USERNAME=${APIM_USERNAME} APIM_PASSWORD="$${APIM_PASSWORD}" APIM_SERVER_URL=${APIM_SERVER_URL} TF_ACC=1 go test -v ./tests/examples
 
 
 .PHONY: help


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1513

## Description

- Updated make targets and CI code to handle special characters in passwords.
- Split CI jobs for example and acceptance tests. This allows running acceptance tests in parallel.
- Example tests can't run in a matrix in parallel because the same resources are updated by several jobs, causing issues. However, I don't think it's necessary to run them with every supported Terraform version, so they were updated to run once with Terraform 1.12.*
- Acceptance tests run in a matrix with all supported Terraform versions and run in parallel.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->