### PR TITLE
GKO-1513 - Run acceptance tests on push only.

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -1,7 +1,6 @@
 name: Terraform Provider Tests
 
 on:
-  pull_request:
   push:
     branches-ignore:
       - master
@@ -48,7 +47,6 @@ jobs:
           - "1.10.*"
           - "1.11.*"
           - "1.12.*"
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.event.pull_request == null)
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-1513

## Description

Updated acceptance tests workflow trigger to run only on push.

I think it's useful to run tests on every push, even if there is no active PR.  And having a trigger on PRs will run tests twice.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

