### PR TITLE
Improve Docker image caching for CI tests

### DIFF
--- a/.github/actions/docker-cache-save/action.yaml
+++ b/.github/actions/docker-cache-save/action.yaml
@@ -1,0 +1,24 @@
+name: docker-cache-save
+description: Save Docker images to cache
+inputs:
+  cache-key:
+    description: Cache key to save
+    required: true
+  cache-path:
+    description: Path to the tar file
+    required: false
+    default: /tmp/docker-images.tar
+  images:
+    description: Space-separated list of Docker images to save
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Save Docker images to tar
+      shell: bash
+      run: docker save -o ${{ inputs.cache-path }} ${{ inputs.images }}
+    - name: Save Docker image cache
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ inputs.cache-path }}
+        key: ${{ inputs.cache-key }}

--- a/.github/actions/pull-docker-image/action.yaml
+++ b/.github/actions/pull-docker-image/action.yaml
@@ -1,0 +1,36 @@
+name: pull-docker-image
+description: Resolve the full image reference and pull it from the registry.
+inputs:
+  image-name:
+    description: The Docker image name (e.g. apim-management-api, mongo)
+    required: true
+  image-tag:
+    description: The Docker image tag (e.g. master-latest, 7.0.23-jammy)
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve cache key
+      id: resolve
+      uses: ./.github/actions/resolve-cache-key
+      with:
+        image-name: ${{ inputs.image-name }}
+        image-tag: ${{ inputs.image-tag }}
+    - name: Resolve image reference
+      id: images
+      shell: bash
+      run: |
+        if [[ "${{ inputs.image-name }}" == "mongo" ]]; then
+          echo "ref=${{ inputs.image-name }}:${{ inputs.image-tag }}" >> "$GITHUB_OUTPUT"
+        else
+          REGISTRY=$(yq '.apim.image.registry' hack/apim.yaml)
+          echo "ref=${REGISTRY}/${{ inputs.image-name }}:${{ inputs.image-tag }}" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Pull image
+      shell: bash
+      run: docker pull "${{ steps.images.outputs.ref }}"
+    - name: Save image cache
+      uses: ./.github/actions/docker-cache-save
+      with:
+        cache-key: ${{ steps.resolve.outputs.value }}
+        images: ${{ steps.images.outputs.ref }}

--- a/.github/actions/resolve-cache-key/action.yaml
+++ b/.github/actions/resolve-cache-key/action.yaml
@@ -1,0 +1,21 @@
+name: resolve-cache-key
+description: Resolve the full Docker cache key for an image. Includes image identity, run metadata, and a hash of infrastructure files.
+inputs:
+  image-name:
+    description: The Docker image name (e.g. apim, mongo)
+    required: true
+  image-tag:
+    description: The Docker image tag (e.g. master-latest, 4.9.x-latest)
+    required: true
+outputs:
+  value:
+    description: The full Docker cache key
+    value: ${{ steps.resolve.outputs.value }}
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve cache key
+      id: resolve
+      shell: bash
+      run: |
+        echo "value=docker-${{ inputs.image-name }}-${{ inputs.image-tag }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ hashFiles('hack/apim.yaml', 'hack/scripts/run-kind.mjs') }}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/restore-docker-image/action.yaml
+++ b/.github/actions/restore-docker-image/action.yaml
@@ -1,0 +1,28 @@
+name: restore-docker-image
+description: Resolve a Docker cache key and restore the image from cache in a single step.
+inputs:
+  image-name:
+    description: The Docker image name (e.g. apim-management-api, mongo)
+    required: true
+  image-tag:
+    description: The Docker image tag (e.g. master-latest, 4.9.x-latest)
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve cache key
+      id: resolve
+      uses: ./.github/actions/resolve-cache-key
+      with:
+        image-name: ${{ inputs.image-name }}
+        image-tag: ${{ inputs.image-tag }}
+    - name: Restore Docker image cache
+      id: docker-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: /tmp/docker-images.tar
+        key: ${{ steps.resolve.outputs.value }}
+    - name: Load Docker images from cache
+      if: steps.docker-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: docker load -i /tmp/docker-images.tar

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -8,8 +8,8 @@ on:
     - cron: 00 05 * * 1-5
 
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   verify-oas:

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -31,7 +31,38 @@ jobs:
           job_status: ${{ job.status }}
           circleci_token: ${{ secrets.CIRCLECI_TOKEN }}
           trigger: test_results_notification
+
+  cache-images:
+    name: Pull Docker image (${{ matrix.image.cache_key }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+    strategy:
+      matrix:
+        image:
+          - name: apim-management-api
+            tag: master-latest
+            cache_key: apim-master-latest
+          - name: apim-management-api
+            tag: 4.9.x-latest
+            cache_key: apim-4.9.x-latest
+          - name: apim-management-api
+            tag: 4.10.x-latest
+            cache_key: apim-4.10.x-latest
+          - name: mongo
+            tag: 7.0.23-jammy
+            cache_key: 7.0.23-jammy
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Pull image
+        uses: ./.github/actions/pull-docker-image
+        with:
+          image-name: ${{ matrix.image.name }}
+          image-tag: ${{ matrix.image.tag }}
+
   examples:
+    needs: [cache-images]
     name: Run Terraform examples (Env ${{ matrix.apim.image_tag }} + Terraform/OpenTofu latest)
     runs-on: ubuntu-latest
     permissions:
@@ -56,6 +87,16 @@ jobs:
         with:
           daemon-config: |
             { "features": { "containerd-snapshotter": false } }
+      - name: Restore APIM image
+        uses: ./.github/actions/restore-docker-image
+        with:
+          image-name: apim-management-api
+          image-tag: ${{ matrix.apim.image_tag }}
+      - name: Restore MongoDB image
+        uses: ./.github/actions/restore-docker-image
+        with:
+          image-name: mongo
+          image-tag: 7.0.23-jammy
       - name: Create test cluster
         env:
           APIM_MINIMAL: true
@@ -92,6 +133,7 @@ jobs:
           trigger: test_results_notification
 
   acceptance:
+    needs: [cache-images]
     name: Acceptance Tests - Version ${{ matrix.apim.image_tag }} - Terraform ${{ matrix.terraform-version }}
     runs-on: ubuntu-latest
     permissions:
@@ -119,6 +161,16 @@ jobs:
         with:
           daemon-config: |
             { "features": { "containerd-snapshotter": false } }
+      - name: Restore APIM image
+        uses: ./.github/actions/restore-docker-image
+        with:
+          image-name: apim-management-api
+          image-tag: ${{ matrix.apim.image_tag }}
+      - name: Restore MongoDB image
+        uses: ./.github/actions/restore-docker-image
+        with:
+          image-name: mongo
+          image-tag: 7.0.23-jammy
       - name: Create test cluster
         env:
           APIM_GRAVITEE_LICENSE: ${{ secrets.GRAVITEE_LICENSE }}


### PR DESCRIPTION
## Summary
- Add a `cache-images` job that pre-pulls Docker images in parallel and saves them to GitHub Actions cache, keyed by run ID, image tag, and infrastructure file hash
- Extract reusable composite actions for pull, save, restore, and cache key resolution under `.github/actions/`
- Acceptance and example test jobs now restore cached images instead of pulling from the registry, reducing redundant pulls across the matrix
- Always re-pull images with mutable tags (e.g. `master-latest`) in local dev to avoid stale images, while skipping pulls for images already present
- Set `fail-fast: false` in the acceptance test matrix so all environments run to completion

## Reusable actions added
| Action | Description |
|---|---|
| `resolve-cache-key` | Builds a deterministic cache key from image identity, run metadata, and infra file hashes |
| `pull-docker-image` | Resolves the full image reference, pulls it, and saves to cache |
| `restore-docker-image` | Restores a cached image tar and loads it into Docker |
| `docker-cache-save` | Saves Docker images to a tar and writes to GitHub Actions cache |

## Test plan
- [ ] Verify `cache-images` job pulls all matrix images successfully
- [ ] Verify acceptance and example jobs restore images from cache and skip redundant pulls
- [ ] Verify local `run-kind.mjs` re-pulls mutable-tagged images and skips already-present ones