### PR TITLE
fix: normalize listener path trailing slash to prevent drift

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   verify-oas:
-    name: Verify OAS schema matches APIM main branch
+    name: Verify OAS schema matches APIM
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: b5451c3d-2473-444c-bd62-9bf8987cd90b
 management:
-  docChecksum: e2cfad01c375b5ec352af6adbda92c81
+  docChecksum: 04cc1de0d4284ff4c410c542876c5540
   docVersion: 1.0.0
   speakeasyVersion: 1.758.0
   generationVersion: 2.866.2
   releaseVersion: 0.5.0
   configChecksum: fdc333758baf25835d67ec9efbdc8f5b
 persistentEdits:
-  generation_id: bdd553e1-ca1a-4f3f-b4ed-6f3f511b8b98
-  pristine_commit_hash: 2d8c44fd5cc543eb5966186b24d30a0f74e5e276
-  pristine_tree_hash: cde2f37137faa2d6234cfb19c45dd86908d4bb6d
+  generation_id: 2cbb9a45-8d32-4337-b250-6449c6988470
+  pristine_commit_hash: 580c530982b4f400ec4dbcd0abbf0563fbae1481
+  pristine_tree_hash: 2df46a8d05df42bc6d0d087f9066b7e5434d94d6
 features:
   terraform:
     additionalDependencies: 0.1.0
@@ -210,8 +210,8 @@ trackedFiles:
     pristine_git_object: 924ad1f461329df763a57f89d25f4104b036540e
   internal/provider/apiv4_resource.go:
     id: 333e3a57e1ff
-    last_write_checksum: sha1:484bd82181936aa366590acf08a5377715b8e329
-    pristine_git_object: 14d861283e0ab85bbd4ff525b2d8c80c028c0c64
+    last_write_checksum: sha1:5d7866e55f4096c00279fe6c204ec4ab1d896933
+    pristine_git_object: 4188b2025838db72bc5a0452ac778e8d42382a67
   internal/provider/apiv4_resource_sdk.go:
     id: ba8026d69f87
     last_write_checksum: sha1:857ebcb33c2f889d86aeb0895fff6bdb54cdedb4

--- a/internal/planmodifiers/stringplanmodifier/normalize_path.go
+++ b/internal/planmodifiers/stringplanmodifier/normalize_path.go
@@ -1,0 +1,40 @@
+package stringplanmodifier
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// NormalizePath returns a plan modifier that suppresses diffs caused by APIM
+// normalizing paths by adding a trailing slash (e.g. "/my-api" → "/my-api/").
+func NormalizePath() planmodifier.String {
+	return normalizePath{}
+}
+
+type normalizePath struct{}
+
+func (m normalizePath) Description(_ context.Context) string {
+	return "Suppresses diff when the only difference is a trailing slash added by APIM."
+}
+
+func (m normalizePath) MarkdownDescription(_ context.Context) string {
+	return "Suppresses diff when the only difference is a trailing slash added by APIM."
+}
+
+func (m normalizePath) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	planVal := req.PlanValue.ValueString()
+	stateVal := req.StateValue.ValueString()
+
+	if !strings.HasSuffix(planVal, "/") && stateVal == planVal+"/" {
+		resp.PlanValue = req.StateValue
+	}
+}

--- a/internal/planmodifiers/stringplanmodifier/normalize_path_test.go
+++ b/internal/planmodifiers/stringplanmodifier/normalize_path_test.go
@@ -1,0 +1,118 @@
+package stringplanmodifier_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestNormalizePath_SuppressTrailingSlashDiff(t *testing.T) {
+	t.Parallel()
+
+	plan := types.StringValue("/my-api")
+	resp := &planmodifier.StringResponse{PlanValue: plan}
+	stringplanmodifier.NormalizePath().PlanModifyString(context.Background(), planmodifier.StringRequest{
+		PlanValue:  plan,
+		StateValue: types.StringValue("/my-api/"),
+	}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors())
+	}
+	if resp.PlanValue.ValueString() != "/my-api/" {
+		t.Fatalf("expected plan value to be /my-api/, got %s", resp.PlanValue.ValueString())
+	}
+}
+
+func TestNormalizePath_NoChangeWhenAlreadyHasSlash(t *testing.T) {
+	t.Parallel()
+
+	plan := types.StringValue("/my-api/")
+	resp := &planmodifier.StringResponse{PlanValue: plan}
+	stringplanmodifier.NormalizePath().PlanModifyString(context.Background(), planmodifier.StringRequest{
+		PlanValue:  plan,
+		StateValue: types.StringValue("/my-api/"),
+	}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors())
+	}
+	if resp.PlanValue.ValueString() != "/my-api/" {
+		t.Fatalf("expected plan value to be /my-api/, got %s", resp.PlanValue.ValueString())
+	}
+}
+
+func TestNormalizePath_NoChangeOnRealDiff(t *testing.T) {
+	t.Parallel()
+
+	plan := types.StringValue("/new-api")
+	resp := &planmodifier.StringResponse{PlanValue: plan}
+	stringplanmodifier.NormalizePath().PlanModifyString(context.Background(), planmodifier.StringRequest{
+		PlanValue:  plan,
+		StateValue: types.StringValue("/old-api/"),
+	}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors())
+	}
+	if resp.PlanValue.ValueString() != "/new-api" {
+		t.Fatalf("expected plan value to remain /new-api, got %s", resp.PlanValue.ValueString())
+	}
+}
+
+func TestNormalizePath_NullPlanValue(t *testing.T) {
+	t.Parallel()
+
+	plan := types.StringNull()
+	resp := &planmodifier.StringResponse{PlanValue: plan}
+	stringplanmodifier.NormalizePath().PlanModifyString(context.Background(), planmodifier.StringRequest{
+		PlanValue:  plan,
+		StateValue: types.StringValue("/my-api/"),
+	}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors())
+	}
+	if !resp.PlanValue.IsNull() {
+		t.Fatal("expected plan value to remain null")
+	}
+}
+
+func TestNormalizePath_NullStateValue(t *testing.T) {
+	t.Parallel()
+
+	plan := types.StringValue("/my-api")
+	resp := &planmodifier.StringResponse{PlanValue: plan}
+	stringplanmodifier.NormalizePath().PlanModifyString(context.Background(), planmodifier.StringRequest{
+		PlanValue:  plan,
+		StateValue: types.StringNull(),
+	}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors())
+	}
+	if resp.PlanValue.ValueString() != "/my-api" {
+		t.Fatalf("expected plan value to remain /my-api, got %s", resp.PlanValue.ValueString())
+	}
+}
+
+func TestNormalizePath_RootPath(t *testing.T) {
+	t.Parallel()
+
+	plan := types.StringValue("/")
+	resp := &planmodifier.StringResponse{PlanValue: plan}
+	stringplanmodifier.NormalizePath().PlanModifyString(context.Background(), planmodifier.StringRequest{
+		PlanValue:  plan,
+		StateValue: types.StringValue("/"),
+	}, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors())
+	}
+	if resp.PlanValue.ValueString() != "/" {
+		t.Fatalf("expected plan value to be /, got %s", resp.PlanValue.ValueString())
+	}
+}

--- a/internal/provider/apiv4_resource.go
+++ b/internal/provider/apiv4_resource.go
@@ -12,6 +12,7 @@ import (
 	custom_listplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/listplanmodifier"
 	speakeasy_listplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/listplanmodifier"
 	speakeasy_objectplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/objectplanmodifier"
+	custom_stringplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/stringplanmodifier"
 	speakeasy_stringplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/gravitee-io/terraform-provider-apim/internal/provider/types"
 	"github.com/gravitee-io/terraform-provider-apim/internal/sdk"
@@ -1459,9 +1460,12 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 												Description: `Override default organization entrypoint with ` + "`" + `host` + "`" + `. Default: false`,
 											},
 											"path": schema.StringAttribute{
-												Computed:    true,
-												Optional:    true,
-												Default:     stringdefault.StaticString(`/`),
+												Computed: true,
+												Optional: true,
+												Default:  stringdefault.StaticString(`/`),
+												PlanModifiers: []planmodifier.String{
+													custom_stringplanmodifier.NormalizePath(),
+												},
 												Description: `Default: "/"`,
 											},
 										},

--- a/schemas/output/computed.yaml
+++ b/schemas/output/computed.yaml
@@ -2044,6 +2044,7 @@ components:
           type: string
           default: "/"
           x-speakeasy-param-computed: false
+          x-speakeasy-plan-modifiers: NormalizePath
         overrideAccess:
           type: boolean
           description: Override default organization entrypoint with `host`

--- a/schemas/overlays/apiv4.yaml
+++ b/schemas/overlays/apiv4.yaml
@@ -320,6 +320,10 @@ actions:
     description: Prevent unknown values if unconfigured
     update:
       x-speakeasy-param-suppress-computed-diff: true
+  - target: $.components.schemas.PathV4.properties.path
+    description: APIM normalizes paths by adding a trailing slash, suppress diff to prevent permanent drift (GKO-2621)
+    update:
+      x-speakeasy-plan-modifiers: NormalizePath
   - target: $.components.schemas.PathV4.properties.overrideAccess
     description: Prevent unknown values if unconfigured
     update:

--- a/tests/acceptance/apiv4_resource_test.go
+++ b/tests/acceptance/apiv4_resource_test.go
@@ -633,5 +633,45 @@ func TestAPIV4Resource_dyn_props(t *testing.T) {
 			},
 		},
 	})
+}
 
+// Verifies that a listener path without trailing slash does not cause permanent drift.
+// APIM normalizes paths by adding a trailing slash, and the provider must suppress
+// the resulting diff to maintain idempotency (GKO-2621).
+func TestAPIV4Resource_path_idempotency(t *testing.T) {
+	t.Parallel()
+
+	environmentId := "DEFAULT"
+	organizationId := "DEFAULT"
+	randomId := "test-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			// Create with path without trailing slash.
+			{
+				ProtoV6ProviderFactories: testProviders(),
+				ConfigDirectory:          config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"environment_id":  config.StringVariable(environmentId),
+					"hrid":            config.StringVariable(randomId),
+					"organization_id": config.StringVariable(organizationId),
+				},
+			},
+			// Re-apply the same config: plan must be empty (idempotency check).
+			{
+				ProtoV6ProviderFactories: testProviders(),
+				ConfigDirectory:          config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"environment_id":  config.StringVariable(environmentId),
+					"hrid":            config.StringVariable(randomId),
+					"organization_id": config.StringVariable(organizationId),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
 }

--- a/tests/acceptance/testdata/TestAPIV4Resource_path_idempotency/main.tf
+++ b/tests/acceptance/testdata/TestAPIV4Resource_path_idempotency/main.tf
@@ -1,0 +1,77 @@
+variable "environment_id" {
+  type = string
+}
+
+variable "hrid" {
+  type = string
+}
+
+variable "organization_id" {
+  type = string
+}
+
+resource "apim_apiv4" "test" {
+  environment_id  = var.environment_id
+  hrid            = var.hrid
+  lifecycle_state = "UNPUBLISHED"
+  name            = "path-idempotency"
+  organization_id = var.organization_id
+  state           = "STOPPED"
+  type            = "PROXY"
+  version         = "1"
+  visibility      = "PRIVATE"
+
+  endpoint_groups = [
+    {
+      name = "Default HTTP proxy group"
+      type = "http-proxy"
+      load_balancer = {
+        type = "ROUND_ROBIN"
+      }
+      services = {}
+      endpoints = [
+        {
+          name = "default"
+          type = "http-proxy"
+          configuration = jsonencode({
+            target = "https://example.com"
+          })
+          services = {}
+        }
+      ]
+    }
+  ]
+
+  listeners = [
+    {
+      http = {
+        entrypoints = [
+          {
+            type = "http-proxy"
+          }
+        ]
+        paths = [
+          {
+            path = "/${var.hrid}"
+          }
+        ]
+        type = "HTTP"
+      }
+    }
+  ]
+
+  plans = [
+    {
+      hrid        = "Keyless"
+      description = "No sec"
+      mode        = "STANDARD"
+      name        = "No security"
+      status      = "PUBLISHED"
+      type        = "API"
+      validation  = "AUTO"
+      security = {
+        type = "KEY_LESS"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- APIM normalizes listener paths by appending a trailing slash (`/my-api` → `/my-api/`), causing permanent drift on every `terraform plan` when users omit it
- Adds a `NormalizePath` custom plan modifier (via OAS overlay `x-speakeasy-plan-modifiers`) on `PathV4.path` that suppresses the diff when the only difference is a server-added trailing slash
- Adds an acceptance test (`TestAPIV4Resource_path_idempotency`) that creates an API with a path without trailing slash and verifies the second plan is empty

Note: `x-speakeasy-param-suppress-computed-diff` alone doesn't work here because `SuppressDiff` only handles Unknown plan values. Since the user explicitly sets the path, a custom modifier is needed to compare the normalized forms.

Fixes [GKO-2621](https://gravitee.atlassian.net/browse/GKO-2621)

## Test plan

- [x] New acceptance test `TestAPIV4Resource_path_idempotency` passes with the fix
- [x] Same test fails without the fix (confirms it reproduces the bug)
- [x] Existing `TestAPIV4Resource_minimal` still passes (no regression)

[GKO-2621]: https://gravitee.atlassian.net/browse/GKO-2621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ