### PR TITLE
Compensate null hrid on updated detached apis

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,12 +5,12 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.761.1
   generationVersion: 2.879.6
-  releaseVersion: 0.5.2
-  configChecksum: 1d579f6d5cf8398c26af85ab1d08af80
+  releaseVersion: 0.5.3
+  configChecksum: 35c64c35510d4a22ac7731e216de058b
 persistentEdits:
-  generation_id: 14532542-7873-482c-9490-0f8555900926
-  pristine_commit_hash: c1dda5a0e6bcf3782a7e5811e1f7906b4d97cf75
-  pristine_tree_hash: edd3698f47261879e529b11bd13d41272dcd2f70
+  generation_id: 2760edca-ba9e-4913-a486-9cb316bbbc02
+  pristine_commit_hash: b93b40fc4391cde1313b1dc6cb4d90ccaf411cba
+  pristine_tree_hash: b6315a676f144c1516f728f20b1cc555450d0e49
 features:
   terraform:
     additionalDependencies: 0.1.0
@@ -556,8 +556,8 @@ trackedFiles:
     pristine_git_object: 748c4bab704e399fd73706ce2a0478fc4a298117
   internal/sdk/graviteeapim.go:
     id: 1f2cf575c2fd
-    last_write_checksum: sha1:221dc94f9ca42e585226c78ae8ea9ef33180ff9d
-    pristine_git_object: 77b2940393d255d00edd6f5c1c0dfec5843edfe8
+    last_write_checksum: sha1:293f057bc090d46d3b82ac2d4f6cf03e961ef74e
+    pristine_git_object: 74a27aafeefbb9b8a517247a2f1ec44594837937
   internal/sdk/internal/config/sdkconfiguration.go:
     id: 6af0bc8635d9
     last_write_checksum: sha1:95294a70d2db0500c6676cbf0936abc8887e68d4

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -35,7 +35,7 @@ go:
   additionalDependencies:
     github.com/golang-jwt/jwt/v5: v5.3.0
 terraform:
-  version: 0.5.2
+  version: 0.5.3
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: {}

--- a/internal/provider/apiv4_resource.go
+++ b/internal/provider/apiv4_resource.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	speakeasy_boolplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/boolplanmodifier"
 	custom_listplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/listplanmodifier"
 	speakeasy_listplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/listplanmodifier"
@@ -39,6 +40,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
 	"regexp"
 )
 
@@ -3234,6 +3237,13 @@ func (r *Apiv4Resource) Read(ctx context.Context, req resource.ReadRequest, resp
 		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res.RawResponse))
 		return
 	}
+
+	// temporary fix for GKO-2821 before we fix the API
+	if res.APIV4State.Hrid == "" {
+		tflog.Warn(ctx, "API returned null HRID; preserving existing state to prevent drift")
+		res.APIV4State.Hrid = data.Hrid.ValueString()
+	}
+
 	resp.Diagnostics.Append(data.RefreshFromSharedApiv4State(ctx, res.APIV4State)...)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/sdk/graviteeapim.go
+++ b/internal/sdk/graviteeapim.go
@@ -159,9 +159,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *GraviteeApim {
 	sdk := &GraviteeApim{
-		SDKVersion: "0.5.2",
+		SDKVersion: "0.5.3",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.5.2 2.879.6 1.0.0 github.com/gravitee-io/terraform-provider-apim/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 0.5.3 2.879.6 1.0.0 github.com/gravitee-io/terraform-provider-apim/internal/sdk",
 			Globals:    globals.Globals{},
 			ServerList: ServerList,
 		},


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2821

## Description

* Set last known HRID to state when API returns null hrid
* Update version to 0.5.3 for rapide release 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

