### PR TITLE
fix: preserve write-only policy config fields dropped by Gravitee GET response

### DIFF
--- a/internal/provider/apiv4_resource_sdk.go
+++ b/internal/provider/apiv4_resource_sdk.go
@@ -18,6 +18,12 @@ import (
 func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, resp *shared.APIV4State) diag.Diagnostics {
 	var diags diag.Diagnostics
 
+	// Capture prior Plans/Flows before the generated code overwrites them so that
+	// write-only policy configuration fields omitted by the Gravitee GET response
+	// (e.g. data-cache timeToLiveSeconds) can be merged back afterward.
+	priorPlans := r.Plans
+	priorFlows := r.Flows
+
 	if resp != nil {
 		if resp.Analytics == nil {
 			r.Analytics = nil
@@ -971,6 +977,7 @@ func (r *Apiv4ResourceModel) RefreshFromSharedApiv4State(ctx context.Context, re
 		}
 	}
 
+	r.preserveWriteOnlyConfigs(priorPlans, priorFlows)
 	return diags
 }
 

--- a/internal/provider/configuration_merge.go
+++ b/internal/provider/configuration_merge.go
@@ -1,0 +1,88 @@
+package provider
+
+import (
+	"encoding/json"
+
+	tfTypes "github.com/gravitee-io/terraform-provider-apim/internal/provider/types"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+)
+
+// mergePreserveState returns apiJSON with any top-level keys from stateJSON added
+// back if they are absent in apiJSON. Keys present in apiJSON are never overwritten —
+// this only fills gaps caused by the Gravitee API not round-tripping write-only fields
+// such as data-cache's timeToLiveSeconds.
+func mergePreserveState(apiJSON, stateJSON []byte) ([]byte, error) {
+	var apiMap map[string]json.RawMessage
+	if err := json.Unmarshal(apiJSON, &apiMap); err != nil {
+		return apiJSON, nil
+	}
+	var stateMap map[string]json.RawMessage
+	if err := json.Unmarshal(stateJSON, &stateMap); err != nil {
+		return apiJSON, nil
+	}
+	for k, v := range stateMap {
+		if _, exists := apiMap[k]; !exists {
+			apiMap[k] = v
+		}
+	}
+	return json.Marshal(apiMap)
+}
+
+// mergeStepConfig merges write-only fields from priorConfig into current and returns the result.
+func mergeStepConfig(current jsontypes.Normalized, prior jsontypes.Normalized) jsontypes.Normalized {
+	if current.IsNull() || current.IsUnknown() {
+		return current
+	}
+	if prior.IsNull() || prior.IsUnknown() {
+		return current
+	}
+	merged, err := mergePreserveState([]byte(current.ValueString()), []byte(prior.ValueString()))
+	if err != nil {
+		return current
+	}
+	return jsontypes.NewNormalizedValue(string(merged))
+}
+
+// mergeFlowSteps merges write-only configuration fields from priorSteps into steps by index.
+func mergeFlowSteps(steps []tfTypes.StepV4, priorSteps []tfTypes.StepV4) {
+	for i := range steps {
+		if i >= len(priorSteps) {
+			break
+		}
+		steps[i].Configuration = mergeStepConfig(steps[i].Configuration, priorSteps[i].Configuration)
+	}
+}
+
+// mergeFlowStepConfigs merges write-only configuration fields from priorFlow into flow for all step types.
+func mergeFlowStepConfigs(flow *tfTypes.FlowV4, priorFlow *tfTypes.FlowV4) {
+	mergeFlowSteps(flow.EntrypointConnect, priorFlow.EntrypointConnect)
+	mergeFlowSteps(flow.Interact, priorFlow.Interact)
+	mergeFlowSteps(flow.Publish, priorFlow.Publish)
+	mergeFlowSteps(flow.Request, priorFlow.Request)
+	mergeFlowSteps(flow.Response, priorFlow.Response)
+	mergeFlowSteps(flow.Subscribe, priorFlow.Subscribe)
+}
+
+// preserveWriteOnlyConfigs re-adds write-only policy configuration fields that the
+// Gravitee API accepts on write but omits from GET responses (e.g. data-cache's
+// timeToLiveSeconds). It must be called after RefreshFromSharedApiv4State with the
+// Plans and Flows values captured before that call.
+func (r *Apiv4ResourceModel) preserveWriteOnlyConfigs(priorPlans []tfTypes.PlanV4, priorFlows []tfTypes.FlowV4) {
+	for planIdx := range r.Plans {
+		if planIdx >= len(priorPlans) {
+			break
+		}
+		for flowIdx := range r.Plans[planIdx].Flows {
+			if flowIdx >= len(priorPlans[planIdx].Flows) {
+				break
+			}
+			mergeFlowStepConfigs(&r.Plans[planIdx].Flows[flowIdx], &priorPlans[planIdx].Flows[flowIdx])
+		}
+	}
+	for flowIdx := range r.Flows {
+		if flowIdx >= len(priorFlows) {
+			break
+		}
+		mergeFlowStepConfigs(&r.Flows[flowIdx], &priorFlows[flowIdx])
+	}
+}

--- a/internal/provider/configuration_merge_test.go
+++ b/internal/provider/configuration_merge_test.go
@@ -1,0 +1,200 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	tfTypes "github.com/gravitee-io/terraform-provider-apim/internal/provider/types"
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestMergePreserveState_PreservesWriteOnlyField(t *testing.T) {
+	apiJSON := []byte(`{"cacheKey":"zoho-access-token","defaultOperation":"SET","resource":"cache-global","value":"{#context.attributes['zoho_access_token']}"}`)
+	stateJSON := []byte(`{"cacheKey":"zoho-access-token","defaultOperation":"SET","resource":"cache-global","timeToLiveSeconds":3500,"value":"{#context.attributes['zoho_access_token']}"}`)
+
+	result, err := mergePreserveState(apiJSON, stateJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(result, &m); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	raw, ok := m["timeToLiveSeconds"]
+	if !ok {
+		t.Fatal("expected timeToLiveSeconds to be preserved from state but it is missing")
+	}
+	if string(raw) != "3500" {
+		t.Fatalf("expected timeToLiveSeconds=3500, got %s", raw)
+	}
+}
+
+func TestMergePreserveState_APIValueWins(t *testing.T) {
+	apiJSON := []byte(`{"cacheKey":"new-key"}`)
+	stateJSON := []byte(`{"cacheKey":"old-key","timeToLiveSeconds":3500}`)
+
+	result, err := mergePreserveState(apiJSON, stateJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(result, &m); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+
+	if string(m["cacheKey"]) != `"new-key"` {
+		t.Fatalf("expected API value to win: cacheKey=%s", m["cacheKey"])
+	}
+	if string(m["timeToLiveSeconds"]) != "3500" {
+		t.Fatalf("expected timeToLiveSeconds preserved from state, got %s", m["timeToLiveSeconds"])
+	}
+}
+
+func TestMergePreserveState_NilStateReturnsAPI(t *testing.T) {
+	apiJSON := []byte(`{"cacheKey":"my-key"}`)
+
+	result, err := mergePreserveState(apiJSON, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != string(apiJSON) {
+		t.Fatalf("expected api JSON unchanged, got %s", result)
+	}
+}
+
+func TestMergePreserveState_NonObjectAPIJSON(t *testing.T) {
+	apiJSON := []byte(`"just-a-string"`)
+	stateJSON := []byte(`{"key":"value"}`)
+
+	result, err := mergePreserveState(apiJSON, stateJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != string(apiJSON) {
+		t.Fatalf("expected non-object API JSON returned unchanged, got %s", result)
+	}
+}
+
+// TestPreserveWriteOnlyConfigs_PlanFlow verifies that after a Read in which the API
+// omits a write-only field (e.g. timeToLiveSeconds), the prior state value for that
+// field is preserved in r.Plans flows.
+func TestPreserveWriteOnlyConfigs_PlanFlow(t *testing.T) {
+	priorConfig := `{"cacheKey":"my-key","defaultOperation":"SET","timeToLiveSeconds":3500}`
+	afterReadConfig := `{"cacheKey":"my-key","defaultOperation":"SET"}` // API dropped timeToLiveSeconds
+
+	r := &Apiv4ResourceModel{
+		Plans: []tfTypes.PlanV4{
+			{
+				Flows: []tfTypes.FlowV4{
+					{
+						Request: []tfTypes.StepV4{
+							{
+								Policy:        types.StringValue("data-cache"),
+								Configuration: jsontypes.NewNormalizedValue(afterReadConfig),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	priorPlans := []tfTypes.PlanV4{
+		{
+			Flows: []tfTypes.FlowV4{
+				{
+					Request: []tfTypes.StepV4{
+						{
+							Policy:        types.StringValue("data-cache"),
+							Configuration: jsontypes.NewNormalizedValue(priorConfig),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	r.preserveWriteOnlyConfigs(priorPlans, nil)
+
+	gotConfig := r.Plans[0].Flows[0].Request[0].Configuration.ValueString()
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(gotConfig), &m); err != nil {
+		t.Fatalf("configuration is not valid JSON: %v", err)
+	}
+	if string(m["timeToLiveSeconds"]) != "3500" {
+		t.Fatalf("expected timeToLiveSeconds=3500 to be preserved, got config: %s", gotConfig)
+	}
+}
+
+// TestPreserveWriteOnlyConfigs_TopLevelFlow verifies the same for top-level flows.
+func TestPreserveWriteOnlyConfigs_TopLevelFlow(t *testing.T) {
+	priorConfig := `{"cacheKey":"my-key","timeToLiveSeconds":3600}`
+	afterReadConfig := `{"cacheKey":"my-key"}` // API dropped timeToLiveSeconds
+
+	r := &Apiv4ResourceModel{
+		Flows: []tfTypes.FlowV4{
+			{
+				Request: []tfTypes.StepV4{
+					{
+						Policy:        types.StringValue("data-cache"),
+						Configuration: jsontypes.NewNormalizedValue(afterReadConfig),
+					},
+				},
+			},
+		},
+	}
+
+	priorFlows := []tfTypes.FlowV4{
+		{
+			Request: []tfTypes.StepV4{
+				{
+					Policy:        types.StringValue("data-cache"),
+					Configuration: jsontypes.NewNormalizedValue(priorConfig),
+				},
+			},
+		},
+	}
+
+	r.preserveWriteOnlyConfigs(nil, priorFlows)
+
+	gotConfig := r.Flows[0].Request[0].Configuration.ValueString()
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(gotConfig), &m); err != nil {
+		t.Fatalf("configuration is not valid JSON: %v", err)
+	}
+	if string(m["timeToLiveSeconds"]) != "3600" {
+		t.Fatalf("expected timeToLiveSeconds=3600 to be preserved, got config: %s", gotConfig)
+	}
+}
+
+// TestPreserveWriteOnlyConfigs_NewStepNoStateToCopy verifies that new steps added
+// after the last state (no prior state entry) are left unchanged.
+func TestPreserveWriteOnlyConfigs_NewStepNoStateToCopy(t *testing.T) {
+	afterReadConfig := `{"cacheKey":"brand-new"}`
+
+	r := &Apiv4ResourceModel{
+		Plans: []tfTypes.PlanV4{
+			{
+				Flows: []tfTypes.FlowV4{
+					{
+						Request: []tfTypes.StepV4{
+							{Configuration: jsontypes.NewNormalizedValue(afterReadConfig)},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// No prior plans at all — simulate first-time creation.
+	r.preserveWriteOnlyConfigs(nil, nil)
+
+	gotConfig := r.Plans[0].Flows[0].Request[0].Configuration.ValueString()
+	if gotConfig != afterReadConfig {
+		t.Fatalf("expected config unchanged, got %s", gotConfig)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes perpetual plan drift caused by the Gravitee Management API accepting certain policy configuration fields on write (PUT/POST) but not returning them on GET. The canonical example is `data-cache`'s `timeToLiveSeconds`.

Upstream API bug: gravitee-io/issues#11423

After `terraform apply`, the next `terraform plan` would always show `+ timeToLiveSeconds = 3500` as a pending change, even with no configuration changes. Applying would "fix" it until the next plan — an unresolvable drift loop.

## How it works

Before the generated `RefreshFromSharedApiv4State` overwrites `r.Plans` and `r.Flows`, we snapshot the prior values. After refresh completes, `preserveWriteOnlyConfigs` walks both trees in parallel by index and merges any key present in prior state but absent from the API response back into the refreshed state. Keys the API *does* return always win.

## Changes

- `internal/provider/configuration_merge.go` — new non-generated file with `mergePreserveState`, `mergeStepConfig`, `mergeFlowStepConfigs`, and `Apiv4ResourceModel.preserveWriteOnlyConfigs`
- `internal/provider/configuration_merge_test.go` — 7 unit tests covering the fix
- `internal/provider/apiv4_resource_sdk.go` — 7 lines added to generated file (snapshot prior state + post-call hook); all logic lives in the non-generated helper

## Test plan

- [x] `make unit-tests` passes (all existing + 7 new tests)
- [ ] Deploy to an environment with a `data-cache` SET step containing `timeToLiveSeconds` and verify `terraform plan` shows no diff after apply