### PR TITLE
Set release version to 1.0.0 (+ small related fixes)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,10 +100,19 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.terraform_gpg_secret_key }}
           passphrase: ${{ secrets.terraform_gpg_passphrase }}
-      - name: Run GoReleaser
+      - name: Run GoReleaser Dry Run
+        if: steps.config.outputs.dry_run == 'true'
         uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
         with:
-          args: ${{ steps.config.outputs.dry_run == 'true' && 'release --snapshot --skip-publish' || 'release --clean' }}
+          args: 'release --snapshot --skip=publish'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+      - name: Run GoReleaser
+        if: steps.config.outputs.dry_run == 'false'
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6.0.0
+        with:
+          args: 'release --clean'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,19 +3,19 @@ id: b5451c3d-2473-444c-bd62-9bf8987cd90b
 management:
   docChecksum: 4c55138f59d17c126a8b2fb86b4a50aa
   docVersion: 1.0.0
-  speakeasyVersion: 1.764.0
-  generationVersion: 2.885.0
-  releaseVersion: 0.9.3
-  configChecksum: f0f7c96e49ef1c9dc320b0429aa16c4e
+  speakeasyVersion: 1.786.1
+  generationVersion: 2.913.3
+  releaseVersion: 1.0.0
+  configChecksum: e4e0dd4531b872006ef64c6bc4d96ead
 persistentEdits:
-  generation_id: c589c243-4c79-42f7-a2ca-1cb68b02444f
-  pristine_commit_hash: cbc69771b05e5db41c672695b421d3ae24daa48c
-  pristine_tree_hash: 9043b9e1b397d4991928ba5774d55433fc01e6d9
+  generation_id: 869727c8-f6a6-4883-8626-3ec7fce7df7c
+  pristine_commit_hash: f3b8dcebad9130cf287da3cc50072e5f618e0b40
+  pristine_tree_hash: d5410224ae83c3a70af4cee0b6980a6288ed226b
 features:
   terraform:
     additionalDependencies: 0.1.0
     constsAndDefaults: 0.3.2
-    core: 3.47.6
+    core: 3.47.9
     deprecations: 2.82.0
     globalSecurity: 2.82.3
     globalServerURLs: 2.83.2
@@ -23,7 +23,7 @@ features:
     groups: 2.81.3
     inputOutputModels: 2.83.0
     nameOverrides: 2.81.7
-    retries: 2.81.4
+    retries: 2.81.5
     typeOverrides: 2.81.1
     unions: 2.82.15
 trackedFiles:
@@ -68,8 +68,8 @@ trackedFiles:
     deleted: true
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:9d5ba45885d22c88c37be3f3be200533932eebdb
-    pristine_git_object: fdea4a893bdcac73dcc874603a75c3d523f200f4
+    last_write_checksum: sha1:39d294c9b291aab7a0f02f6af5671425d3093733
+    pristine_git_object: db191d6dc05789e9b346befb38bd082942db83a9
   examples/resources/apim_dictionary/import-by-string-id.tf:
     id: fca6a77866a2
     last_write_checksum: sha1:89ad645d4877d71e58e412972d25d4369d478906
@@ -84,8 +84,8 @@ trackedFiles:
     pristine_git_object: 61c8795f8d113867da78d3095a87072eb05a15c1
   go.mod:
     id: c47645c391ad
-    last_write_checksum: sha1:b27593e702eb1a4896deab1d946734dd02c93f3b
-    pristine_git_object: 5a94a6ab9c790c123bca91554b2f5b752922b903
+    last_write_checksum: sha1:73eb3d1c863d81c9b5993254763d2b29392c4bea
+    pristine_git_object: ea2eda343c8e25526be14b9879d330612bc1d486
   internal/planmodifiers/boolplanmodifier/suppress_diff.go:
     id: 3cf85b98963e
     last_write_checksum: sha1:70b2947d6f36ee573a1b8668684abf94304b7ba7
@@ -292,7 +292,7 @@ trackedFiles:
     pristine_git_object: 82a8266240c0a51f132fcb29c88ec4679649ad08
   internal/provider/provider.go:
     id: 1e7e86841cf3
-    last_write_checksum: sha1:dd0c04e006646bfbc47d66e190491506713350e3
+    last_write_checksum: sha1:45c95fc474a4b5c710849a16808448d0fc9409aa
     pristine_git_object: c2778feb2568c75764140322353ef7d5dd0506d8
   internal/provider/reflect/diags.go:
     id: 35b6b44972e2
@@ -666,8 +666,8 @@ trackedFiles:
     pristine_git_object: 748c4bab704e399fd73706ce2a0478fc4a298117
   internal/sdk/graviteeapim.go:
     id: 1f2cf575c2fd
-    last_write_checksum: sha1:ca9ec37214eda6116e709e3696ff5a9cc00e50b9
-    pristine_git_object: 9eb1b3947572e91d4d672946a21aa82d237b7d79
+    last_write_checksum: sha1:b882a78272aabb4756acf28bd594fc8dd373738d
+    pristine_git_object: 52f4a99576c06708c28d5c1b0fa79696466777cf
   internal/sdk/groups.go:
     id: 2bfe17bcb000
     last_write_checksum: sha1:709108650e6e2f0612bad64fe38a49f88aefd495
@@ -1208,8 +1208,8 @@ trackedFiles:
     pristine_git_object: 1a9bcd0cc4a56f4034599c5a32058b0490dd17f8
   internal/sdk/retry/config.go:
     id: 7ea5fa9128b6
-    last_write_checksum: sha1:1cdb99de13f9db4dbcd610122cef47332cf02ec7
-    pristine_git_object: c9fb2a2267b398e2bcabbb199d6636ef8887d004
+    last_write_checksum: sha1:22068a7fd6e154053ff85678a7fdb6a0d02ac790
+    pristine_git_object: 225f89fa83232afd070195744a60dbcf308996a7
   internal/sdk/sharedpolicygroups.go:
     id: b191c7e7c928
     last_write_checksum: sha1:6a1994627f4f1fb2850ad35302df1f9c7906af10

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -35,7 +35,7 @@ go:
   additionalDependencies:
     github.com/golang-jwt/jwt/v5: v5.3.0
 terraform:
-  version: 0.9.3
+  version: 1.0.0
   additionalActions: []
   additionalDataSources: []
   additionalDependencies: {}

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.764.0
+speakeasyVersion: 1.786.1
 sources:
     Gravitee.io - Automation API:
         sourceNamespace: gravitee-io-gko---automation-api
@@ -27,7 +27,7 @@ targets:
         sourceBlobDigest: sha256:e5bdd28116e0660af601a098573e8a5044ef09f829e56844984aec28f40ca240
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: 1.764.0
+    speakeasyVersion: 1.786.1
     sources:
         automation-api:
             inputs:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.764.0
+speakeasyVersion: 1.786.1
 sources:
     automation-api:
         inputs:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ APIM_PASSWORD ?= admin
 APIM_API1_USERNAME ?= api1
 APIM_API1_PASSWORD ?= api1
 APIM_SERVER_URL ?= http://localhost:30083/automation
-APIM_OAS_BRANCH=master
+APIM_OAS_BRANCH=4.12.x
 
 .PHONY: speakeasy
 speakeasy: ## Run speakeasy generation with curated examples and docs

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ terraform {
   required_providers {
     apim = {
       source  = "gravitee-io/apim"
-      version = "0.9.3"
+      version = "1.0.0"
     }
   }
 }

--- a/docs/guides/docgen_export-tutorial.md
+++ b/docs/guides/docgen_export-tutorial.md
@@ -444,7 +444,6 @@ resource "apim_apiv4" "export" {
     {
       default_value = "support@change.me"
       format        = "MAIL"
-      hidden        = false
       key           = "email-support"
       name          = "email-support"
       value         = "$${(api.primaryOwner.email)!''}"

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ terraform {
   required_providers {
     apim = {
       source  = "gravitee-io/apim"
-      version = "0.9.3"
+      version = "1.0.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     apim = {
       source  = "gravitee-io/apim"
-      version = "0.9.3"
+      version = "1.0.0"
     }
   }
 }

--- a/examples/tutorials/hcl-export/exported.tf
+++ b/examples/tutorials/hcl-export/exported.tf
@@ -133,7 +133,6 @@ resource "apim_apiv4" "export" {
     {
       default_value = "support@change.me"
       format        = "MAIL"
-      hidden        = false
       key           = "email-support"
       name          = "email-support"
       value         = "$${(api.primaryOwner.email)!''}"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitee-io/terraform-provider-apim
 
-go 1.26
+go 1.25.10
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/internal/sdk/graviteeapim.go
+++ b/internal/sdk/graviteeapim.go
@@ -3,7 +3,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 1.0.0 and generator version 2.885.0
+// Generated from OpenAPI doc version 1.0.0 and generator version 2.913.3
 
 import (
 	"context"
@@ -163,9 +163,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *GraviteeApim {
 	sdk := &GraviteeApim{
-		SDKVersion: "0.9.3",
+		SDKVersion: "1.0.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 0.9.3 2.885.0 1.0.0 github.com/gravitee-io/terraform-provider-apim/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.0.0 2.913.3 1.0.0 github.com/gravitee-io/terraform-provider-apim/internal/sdk",
 			Globals:    globals.Globals{},
 			ServerList: ServerList,
 		},

--- a/internal/sdk/retry/config.go
+++ b/internal/sdk/retry/config.go
@@ -99,6 +99,14 @@ func retryIntervalFromResponse(res *http.Response) time.Duration {
 		return 0
 	}
 
+	retryAfterMsVal := res.Header.Get("retry-after-ms")
+	if retryAfterMsVal != "" {
+		parsedMs, err := strconv.ParseInt(retryAfterMsVal, 10, 64)
+		if err == nil && parsedMs >= 0 {
+			return time.Duration(parsedMs) * time.Millisecond
+		}
+	}
+
 	retryVal := res.Header.Get("retry-after")
 	if retryVal == "" {
 		return 0

--- a/templates/guides/docgen_export-tutorial.md
+++ b/templates/guides/docgen_export-tutorial.md
@@ -444,7 +444,6 @@ resource "apim_apiv4" "export" {
     {
       default_value = "support@change.me"
       format        = "MAIL"
-      hidden        = false
       key           = "email-support"
       name          = "email-support"
       value         = "$${(api.primaryOwner.email)!''}"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2591

## Description

Switch to version 1.0.0 before actual release
=> need to make that we agree on https://github.com/gravitee-io/terraform-provider-apim/pull/129 first

- [x] rebase
- [x] change commit to `release: 1.0.0` 
- [x] squash merge once ready => that should check and trigger the release

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

