### PR TITLE
ci: restore scheduled Slack notifications and run tests daily

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
   pull_request:
   schedule:
-    - cron: 00 05 * * 1-5
+    - cron: 00 05 * * *
   workflow_dispatch:
 
 concurrency:
@@ -26,6 +26,7 @@ jobs:
         uses: ./.github/actions/verify-oas-upstream
       - name: Send slack notification
         if: (failure() || success()) && github.event.schedule != ''
+        continue-on-error: true
         uses: ./.github/actions/send-slack-notification
         with:
           job_name: ${{ github.job }}
@@ -113,6 +114,7 @@ jobs:
         run: make examples-tests
       - name: Send Slack notification
         if: (failure() || success()) && github.event.schedule != ''
+        continue-on-error: true
         uses: ./.github/actions/send-slack-notification
         with:
           job_name: ${{ github.job }} - APIM ${{ matrix.apim.image_tag }} - Terraform ${{ matrix.terraform-version }}

--- a/hack/scripts/package-lock.json
+++ b/hack/scripts/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "scripts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "zx": "^8.3.0"
+      }
+    },
+    "node_modules/zx": {
+      "version": "8.8.5",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-8.8.5.tgz",
+      "integrity": "sha512-SNgDF5L0gfN7FwVOdEFguY3orU5AkfFZm9B5YSHog/UDHv+lvmd82ZAsOenOkQixigwH2+yyH198AwNdKhj+RA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "zx": "build/cli.js"
+      },
+      "engines": {
+        "node": ">= 12.17.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `hack/scripts/package-lock.json` so `npm ci` in the Slack notification action succeeds again (broken since commit c0ccacd switched to `npm ci` without committing the lockfile).
- Run the acceptance workflow cron every day (`00 05 * * *`) instead of weekdays only.
- Mark Slack notification steps as `continue-on-error: true` so a notification failure cannot fail an otherwise green test job.

## Test plan

- [ ] Merge and wait for the next scheduled run (05:00 UTC), or trigger `workflow_dispatch` on the acceptance workflow.
- [ ] Confirm Slack notifications are received for scheduled runs.
- [ ] Confirm scheduled workflow conclusion reflects test results, not notification step failures.