### PR TITLE
fix(cloud): validate resource scope against cloud token (GKO-2961)

### DIFF
--- a/internal/provider/cloud_scope_transport.go
+++ b/internal/provider/cloud_scope_transport.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var cloudScopePathPatternOrg = regexp.MustCompile(`/organizations/([^/]+)`)
+var cloudScopePathPatternOrgEnv = regexp.MustCompile(`/organizations/([^/]+)/environments/([^/]+)`)
+
+type cloudScopeTransport struct {
+	transport http.RoundTripper
+	claims    *CloudTokenClaimsData
+}
+
+func NewCloudScopeTransport(transport http.RoundTripper, claims *CloudTokenClaimsData) http.RoundTripper {
+	if claims == nil {
+		return transport
+	}
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	return &cloudScopeTransport{
+		transport: transport,
+		claims:    claims,
+	}
+}
+
+func (t *cloudScopeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	orgEnv, ok := scopeFromRequestPath(req.URL.Path)
+	if ok {
+		if err := validateCloudScope(*t.claims, orgEnv); err != nil {
+			defer func() {
+				if req != nil && req.Body != nil {
+					_ = req.Body.Close()
+				}
+			}()
+			tflog.Debug(req.Context(), "cloud token scope violation", map[string]interface{}{
+				"error": err,
+			})
+			return nil, fmt.Errorf("cloud token scope violation: %w", err)
+		}
+	}
+	return t.transport.RoundTrip(req)
+}
+
+func scopeFromRequestPath(path string) (orgEnv, bool) {
+	matchesOrgEnv := cloudScopePathPatternOrgEnv.FindStringSubmatch(path)
+	if len(matchesOrgEnv) == 3 {
+		return orgEnv{Org: matchesOrgEnv[1], Env: matchesOrgEnv[2]}, true
+	}
+	matchesOrgOnly := cloudScopePathPatternOrg.FindStringSubmatch(path)
+	if len(matchesOrgOnly) == 2 {
+		return orgEnv{Org: matchesOrgOnly[1]}, true
+	}
+	return orgEnv{}, false
+}

--- a/internal/provider/cloud_scope_transport_test.go
+++ b/internal/provider/cloud_scope_transport_test.go
@@ -1,0 +1,153 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloudScopeTransportAllowsPermittedScope(t *testing.T) {
+	claims := loadTestCloudClaims(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	client := &http.Client{
+		Transport: NewCloudScopeTransport(http.DefaultTransport, &claims),
+	}
+
+	req, err := http.NewRequest(http.MethodPut, server.URL+"/organizations/"+claims.Org+"/environments/"+claims.Envs[0]+"/apis", nil)
+	require.NoError(t, err)
+
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func TestCloudScopeTransportAllowsPermittedScopeOrgOnly(t *testing.T) {
+	claims := loadTestCloudClaims(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	client := &http.Client{
+		Transport: NewCloudScopeTransport(http.DefaultTransport, &claims),
+	}
+
+	req, err := http.NewRequest(http.MethodPut, server.URL+"/organizations/"+claims.Org+"/settings", nil)
+	require.NoError(t, err)
+
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func TestCloudScopeTransportRejectsUnauthorizedEnvironment(t *testing.T) {
+	claims := loadTestCloudClaims(t)
+
+	transport := NewCloudScopeTransport(http.DefaultTransport, &claims)
+	req, err := http.NewRequest(http.MethodPut, "http://example.com/organizations/"+claims.Org+"/environments/unauthorized-env/apis", nil)
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cloud token scope violation")
+	assert.Contains(t, err.Error(), "unauthorized-env")
+}
+
+func TestCloudScopeTransportRejectsUnauthorizedOrgOnly(t *testing.T) {
+	claims := loadTestCloudClaims(t)
+
+	transport := NewCloudScopeTransport(http.DefaultTransport, &claims)
+	req, err := http.NewRequest(http.MethodPut, "http://example.com/organizations/unauthorized-org/settings", nil)
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cloud token scope violation")
+	assert.Contains(t, err.Error(), "unauthorized-org")
+}
+
+func TestCloudScopeTransportRejectsUnauthorizedOrganization(t *testing.T) {
+	claims := loadTestCloudClaims(t)
+
+	transport := NewCloudScopeTransport(http.DefaultTransport, &claims)
+	req, err := http.NewRequest(http.MethodPut, "http://example.com/organizations/unauthorized-org/environments/"+claims.Envs[0]+"/apis", nil)
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cloud token scope violation")
+	assert.Contains(t, err.Error(), "unauthorized-org")
+}
+
+func TestCloudScopeTransportPassthroughWithoutClaims(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	client := &http.Client{
+		Transport: NewCloudScopeTransport(http.DefaultTransport, nil),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/organizations/any/environments/any/apis", nil)
+	require.NoError(t, err)
+
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	assert.Equal(t, http.StatusNoContent, res.StatusCode)
+}
+
+func TestCloudScopeTransportIgnoresPathsWithoutScope(t *testing.T) {
+	claims := loadTestCloudClaims(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	client := &http.Client{
+		Transport: NewCloudScopeTransport(http.DefaultTransport, &claims),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/health", nil)
+	require.NoError(t, err)
+
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func TestScopeFromRequestPath(t *testing.T) {
+	orgEnv, ok := scopeFromRequestPath("/organizations/org-1/environments/env-1/apis/demo")
+	assert.True(t, ok)
+	assert.Equal(t, "org-1", orgEnv.Org)
+	assert.Equal(t, "env-1", orgEnv.Env)
+
+	_, ok = scopeFromRequestPath("/health")
+	assert.False(t, ok)
+}
+
+func loadTestCloudClaims(t *testing.T) CloudTokenClaimsData {
+	t.Helper()
+
+	file, err := os.ReadFile("testdata/cloud-token.jwt")
+	require.NoError(t, err)
+
+	claims, err := extractCloudTokenData(string(file))
+	require.NoError(t, err)
+	return claims
+}

--- a/internal/provider/gravitee_cloud.go
+++ b/internal/provider/gravitee_cloud.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -9,22 +10,41 @@ import (
 	"github.com/gravitee-io/terraform-provider-apim/internal/sdk/models/shared"
 	tfp "github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 const cloudGateUrlTemplate = "https://%s.cloudgate.gravitee.io/apim/automation"
 
 var defaultCloudUrl = fmt.Sprintf(cloudGateUrlTemplate, "eu")
 
-// CloudInitializer setup url/env/org if required. Keeps non default value intact
-func CloudInitializer(auth shared.Security, serverUrl string, data *ApimProviderModel, resp *tfp.ConfigureResponse) string {
+// CloudInitResult holds provider configuration derived from a Gravitee Cloud token.
+type CloudInitResult struct {
+	ServerURL string
+	Claims    *CloudTokenClaimsData
+}
+
+type orgEnv struct {
+	Org string
+	Env string
+}
+
+func fromData(data *ApimProviderModel) orgEnv {
+	return orgEnv{
+		Org: data.OrganizationID.ValueString(),
+		Env: data.EnvironmentID.ValueString(),
+	}
+}
+
+// CloudInitializer setup url/env/org if required. Keeps non default value intact.
+func CloudInitializer(ctx context.Context, auth shared.Security, serverUrl string, data *ApimProviderModel, resp *tfp.ConfigureResponse) CloudInitResult {
 	if auth.CloudAuth == nil {
-		return serverUrl
+		return CloudInitResult{ServerURL: serverUrl}
 	}
 
 	jwtData, err := extractCloudTokenData(*auth.CloudAuth)
 	if err != nil {
 		resp.Diagnostics.AddError("Cloud Token invalid", err.Error())
-		return serverUrl
+		return CloudInitResult{ServerURL: serverUrl}
 	}
 
 	if configuredEnvID := data.EnvironmentID.ValueString(); configuredEnvID == "DEFAULT" {
@@ -34,33 +54,52 @@ func CloudInitializer(auth shared.Security, serverUrl string, data *ApimProvider
 			resp.Diagnostics.AddError(
 				"Cloud Token incompatible",
 				fmt.Sprintf("cloud token contains more than one environment (%d): environment_id is required in that case", len(jwtData.Envs)))
-			return serverUrl
+			return CloudInitResult{ServerURL: serverUrl}
 		}
 		data.EnvironmentID = basetypes.NewStringValue(jwtData.Envs[0])
-	} else if !slices.Contains(jwtData.Envs, configuredEnvID) {
-		// if set, check env in token
-		resp.Diagnostics.AddError("Cloud Token misconfiguration",
-			fmt.Sprintf("cloud token does not contain environment [%s], it must be one of: %s", configuredEnvID, jwtData.Envs))
-		return serverUrl
+	} else if err := validateCloudScope(jwtData, fromData(data)); err != nil {
+		tflog.Error(ctx, "cloud token scope violation", map[string]interface{}{
+			"error": err,
+		})
+		resp.Diagnostics.AddError("Cloud Token misconfiguration", err.Error())
+		return CloudInitResult{ServerURL: serverUrl}
 	}
 
 	// Set if unset
 	if configuredOrgID := data.OrganizationID.ValueString(); configuredOrgID == "DEFAULT" {
 		data.OrganizationID = basetypes.NewStringValue(jwtData.Org)
-	} else if configuredOrgID != jwtData.Org {
-		// if set, check env in token
-		resp.Diagnostics.AddError("Cloud Token misconfiguration",
-			fmt.Sprintf("cloud token specifies organization [%s] you cannot use [%s] for organization_id value", jwtData.Org, configuredOrgID))
-		return serverUrl
+	} else if err := validateCloudScope(jwtData, fromData(data)); err != nil {
+		tflog.Error(ctx, "cloud token scope violation", map[string]interface{}{
+			"error": err,
+		})
+		resp.Diagnostics.AddError("Cloud Token misconfiguration", err.Error())
+		return CloudInitResult{ServerURL: serverUrl}
+	}
+
+	claims := jwtData
+	result := CloudInitResult{
+		ServerURL: serverUrl,
+		Claims:    &claims,
 	}
 
 	// Return user defined URL
 	if serverUrl != defaultCloudUrl {
-		return serverUrl
+		return result
 	}
 
 	// returned computed URL
-	return jwtData.baseUrl()
+	result.ServerURL = jwtData.baseUrl()
+	return result
+}
+
+func validateCloudScope(claims CloudTokenClaimsData, orgEnv orgEnv) error {
+	if orgEnv.Env != "" && orgEnv.Env != "DEFAULT" && !slices.Contains(claims.Envs, orgEnv.Env) {
+		return fmt.Errorf("cloud token does not contain environment [%s], it must be one of: %s", orgEnv.Env, claims.Envs)
+	}
+	if orgEnv.Org != "" && orgEnv.Org != "DEFAULT" && orgEnv.Org != claims.Org {
+		return fmt.Errorf("cloud token specifies organization [%s], you cannot use [%s] for organization_id value", claims.Org, orgEnv.Org)
+	}
+	return nil
 }
 
 func extractCloudTokenData(jwtToken string) (CloudTokenClaimsData, error) {

--- a/internal/provider/gravitee_cloud_test.go
+++ b/internal/provider/gravitee_cloud_test.go
@@ -18,12 +18,13 @@ func TestCloudInitializerNoCloudAuth(t *testing.T) {
 	var data *ApimProviderModel
 	var resp *tfp.ConfigureResponse
 
-	url := CloudInitializer(auth, serverUrl, data, resp)
-	assert.Equal(t, url, serverUrl)
+	result := CloudInitializer(t.Context(), auth, serverUrl, data, resp)
+	assert.Equal(t, serverUrl, result.ServerURL)
+	assert.Nil(t, result.Claims)
 
 }
 
-func TestCloudInitializerValidTokenAndConfig(t *testing.T) {
+func TestCloudInitializerValidTokenAndDefaultConfig(t *testing.T) {
 	file, err := os.ReadFile("testdata/cloud-token.jwt")
 	assert.NoError(t, err)
 
@@ -40,11 +41,33 @@ func TestCloudInitializerValidTokenAndConfig(t *testing.T) {
 		Diagnostics: make(diag.Diagnostics, 0),
 	}
 
-	url := CloudInitializer(auth, defaultCloudUrl, data, resp)
-	assert.Equal(t, url, defaultCloudUrl)
+	result := CloudInitializer(t.Context(), auth, defaultCloudUrl, data, resp)
 	assert.Len(t, resp.Diagnostics, 0)
-	assert.NotEqual(t, "DEFAULT", data.OrganizationID.ValueString())
-	assert.NotEqual(t, "DEFAULT", data.EnvironmentID.ValueString())
+	assert.Equal(t, defaultCloudUrl, result.ServerURL)
+	assert.Equal(t, result.Claims.Org, data.OrganizationID.ValueString())
+	assert.Equal(t, result.Claims.Envs[0], data.EnvironmentID.ValueString())
+}
+
+func TestCloudInitializerValidTokenAndMatchingConfig(t *testing.T) {
+	file, err := os.ReadFile("testdata/cloud-token.jwt")
+	assert.NoError(t, err)
+
+	cloudAuth := string(file)
+	auth := shared.Security{
+		CloudAuth: &cloudAuth,
+	}
+
+	data := &ApimProviderModel{
+		EnvironmentID:  types.StringValue("9b5e326f-f68a-45f9-9e32-6ff68ae5f92c"),
+		OrganizationID: types.StringValue("2806dece-d045-463d-86de-ced045963d84"),
+	}
+	resp := &tfp.ConfigureResponse{
+		Diagnostics: make(diag.Diagnostics, 0),
+	}
+
+	url := CloudInitializer(t.Context(), auth, defaultCloudUrl, data, resp)
+	assert.Equal(t, defaultCloudUrl, url.ServerURL)
+	assert.Len(t, resp.Diagnostics, 0)
 
 }
 
@@ -66,8 +89,9 @@ func TestCloudInitializerValidTokenAndNonDefaultURL(t *testing.T) {
 	}
 
 	serverUrl := "http://localhost"
-	url := CloudInitializer(auth, serverUrl, data, resp)
-	assert.Equal(t, url, serverUrl)
+	result := CloudInitializer(t.Context(), auth, serverUrl, data, resp)
+	assert.NotEqual(t, "http://localhost", result.Claims.baseUrl())
+	assert.Equal(t, serverUrl, result.ServerURL)
 	assert.Len(t, resp.Diagnostics, 0)
 	assert.NotEqual(t, "DEFAULT", data.OrganizationID.ValueString())
 	assert.NotEqual(t, "DEFAULT", data.EnvironmentID.ValueString())
@@ -91,8 +115,9 @@ func TestCloudInitializerValidTokenNonDefaultGeography(t *testing.T) {
 		Diagnostics: make(diag.Diagnostics, 0),
 	}
 
-	url := CloudInitializer(auth, defaultCloudUrl, data, resp)
-	assert.Equal(t, fmt.Sprintf(cloudGateUrlTemplate, "us"), url)
+	result := CloudInitializer(t.Context(), auth, defaultCloudUrl, data, resp)
+	assert.Equal(t, "us", result.Claims.Geography)
+	assert.Equal(t, fmt.Sprintf(cloudGateUrlTemplate, "us"), result.ServerURL)
 	assert.Len(t, resp.Diagnostics, 0)
 	assert.NotEqual(t, "DEFAULT", data.OrganizationID.ValueString())
 	assert.NotEqual(t, "DEFAULT", data.EnvironmentID.ValueString())
@@ -116,8 +141,8 @@ func TestCloudInitializerValidToken2Envs(t *testing.T) {
 		Diagnostics: make(diag.Diagnostics, 0),
 	}
 
-	url := CloudInitializer(auth, defaultCloudUrl, data, resp)
-	assert.Equal(t, url, defaultCloudUrl)
+	result := CloudInitializer(t.Context(), auth, defaultCloudUrl, data, resp)
+	assert.Equal(t, defaultCloudUrl, result.ServerURL)
 	assert.Len(t, resp.Diagnostics, 1)
 	assert.Equal(t, resp.Diagnostics[0].Severity(), diag.SeverityError)
 	assert.Contains(t, resp.Diagnostics[0].Detail(), "environment_id is required")
@@ -142,7 +167,7 @@ func TestCloudInitializerValidTokenWrongEnv(t *testing.T) {
 		Diagnostics: make(diag.Diagnostics, 0),
 	}
 
-	_ = CloudInitializer(auth, serverUrl, data, resp)
+	_ = CloudInitializer(t.Context(), auth, serverUrl, data, resp)
 	assert.Len(t, resp.Diagnostics, 1)
 	assert.Equal(t, resp.Diagnostics[0].Severity(), diag.SeverityError)
 	assert.Contains(t, resp.Diagnostics[0].Detail(), "[foo]")
@@ -166,7 +191,7 @@ func TestCloudInitializerValidTokenWrongOrg(t *testing.T) {
 		Diagnostics: make(diag.Diagnostics, 0),
 	}
 
-	_ = CloudInitializer(auth, serverUrl, data, resp)
+	_ = CloudInitializer(t.Context(), auth, serverUrl, data, resp)
 	assert.Len(t, resp.Diagnostics, 1)
 	assert.Equal(t, resp.Diagnostics[0].Severity(), diag.SeverityError)
 	assert.Contains(t, resp.Diagnostics[0].Detail(), "[foo]")
@@ -190,7 +215,7 @@ func TestCloudInitializerValidInvalidToken(t *testing.T) {
 		Diagnostics: make(diag.Diagnostics, 0),
 	}
 
-	_ = CloudInitializer(auth, serverUrl, data, resp)
+	_ = CloudInitializer(t.Context(), auth, serverUrl, data, resp)
 	assert.Len(t, resp.Diagnostics, 1)
 	assert.Equal(t, resp.Diagnostics[0].Severity(), diag.SeverityError)
 	assert.Contains(t, resp.Diagnostics[0].Summary(), "invalid")
@@ -215,7 +240,7 @@ func TestCloudInitializerValidNotCloudToken(t *testing.T) {
 		Diagnostics: make(diag.Diagnostics, 0),
 	}
 
-	_ = CloudInitializer(auth, serverUrl, data, resp)
+	_ = CloudInitializer(t.Context(), auth, serverUrl, data, resp)
 	assert.Len(t, resp.Diagnostics, 1)
 	assert.Equal(t, resp.Diagnostics[0].Severity(), diag.SeverityError)
 	assert.Contains(t, resp.Diagnostics[0].Summary(), "invalid")

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -191,7 +191,8 @@ func (p *ApimProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	}
 
 	// BEGIN GRAVITEE CLOUD INIT
-	serverUrl = CloudInitializer(security, serverUrl, &data, resp)
+	cloudInit := CloudInitializer(ctx, security, serverUrl, &data, resp)
+	serverUrl = cloudInit.ServerURL
 	// END GRAVITEE CLOUD INIT
 	providerHTTPTransportOpts := ProviderHTTPTransportOpts{
 		SetHeaders: make(map[string]string),
@@ -204,7 +205,10 @@ func (p *ApimProvider) Configure(ctx context.Context, req provider.ConfigureRequ
 	}
 
 	httpClient := http.DefaultClient
-	httpClient.Transport = NewProviderHTTPTransport(providerHTTPTransportOpts)
+	httpClient.Transport = NewCloudScopeTransport(
+		NewProviderHTTPTransport(providerHTTPTransportOpts),
+		cloudInit.Claims,
+	)
 
 	opts := []sdk.SDKOption{
 		sdk.WithServerURL(serverUrl),

--- a/tests/acceptance/cloud_scope_test.go
+++ b/tests/acceptance/cloud_scope_test.go
@@ -1,0 +1,139 @@
+package acceptance_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const (
+	cloudTestOrg  = "2806dece-d045-463d-86de-ced045963d84"
+	cloudTestEnv  = "9b5e326f-f68a-45f9-9e32-6ff68ae5f92c"
+	cloudTestEnv2 = "357c35e3-6635-443a-9812-312e2f548606"
+	cloudWrongOrg = "00000000-0000-0000-0000-000000000001"
+	cloudWrongEnv = "11111111-1111-1111-1111-111111111111"
+)
+
+// Verifies cloud token scope validation rejects misconfiguration before API calls.
+func TestCloudAuthScope_rejectsUnauthorizedScope(t *testing.T) {
+	
+	randomID := "test-" + acctest.RandString(10)
+	validToken := buildCloudToken(t, validCloudTokenClaims())
+	multiEnvToken := buildCloudToken(t, validCloudTokenClaims(cloudTestEnv, cloudTestEnv2))
+	nonCloudToken := buildCloudToken(t, map[string]any{
+		"sub": "1234567890",
+	})
+
+	baseVars := config.Variables{
+		"hrid": config.StringVariable(randomID),
+	}
+
+	resource.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				ProtoV6ProviderFactories: testProviders(),
+				ConfigDirectory:          config.TestNameDirectory(),
+				ConfigVariables: mergeVariables(baseVars, config.Variables{
+					"cloud_token": config.StringVariable("not-a-jwt"),
+				}),
+				ExpectError: regexp.MustCompile(`Cloud Token invalid`),
+			},
+			{
+				ProtoV6ProviderFactories: testProviders(),
+				ConfigDirectory:          config.TestNameDirectory(),
+				ConfigVariables: mergeVariables(baseVars, config.Variables{
+					"cloud_token": config.StringVariable(nonCloudToken),
+				}),
+				ExpectError: regexp.MustCompile(`required claims`),
+			},
+			{
+				ProtoV6ProviderFactories: testProviders(),
+				ConfigDirectory:          config.TestNameDirectory(),
+				ConfigVariables: mergeVariables(baseVars, config.Variables{
+					"cloud_token": config.StringVariable(multiEnvToken),
+				}),
+				ExpectError: regexp.MustCompile(`Cloud Token incompatible`),
+			},
+			{
+				ProtoV6ProviderFactories: testProviders(),
+				ConfigDirectory:          config.TestNameDirectory(),
+				ConfigVariables: mergeVariables(baseVars, config.Variables{
+					"cloud_token":             config.StringVariable(validToken),
+					"provider_environment_id": config.StringVariable(cloudWrongEnv),
+				}),
+				ExpectError: regexp.MustCompile(`Cloud Token misconfiguration`),
+			},
+			{
+				ProtoV6ProviderFactories: testProviders(),
+				ConfigDirectory:          config.TestNameDirectory(),
+				ConfigVariables: mergeVariables(baseVars, config.Variables{
+					"cloud_token":              config.StringVariable(validToken),
+					"provider_organization_id": config.StringVariable(cloudWrongOrg),
+				}),
+				ExpectError: regexp.MustCompile(`Cloud Token misconfiguration`),
+			},
+			{
+				ProtoV6ProviderFactories: testProviders(),
+				ConfigDirectory:          config.TestNameDirectory(),
+				ConfigVariables: mergeVariables(baseVars, config.Variables{
+					"cloud_token":             config.StringVariable(validToken),
+					"resource_environment_id": config.StringVariable(cloudWrongEnv),
+				}),
+				ExpectError: regexp.MustCompile(`cloud token scope violation`),
+			},
+			{
+				ProtoV6ProviderFactories: testProviders(),
+				ConfigDirectory:          config.TestNameDirectory(),
+				ConfigVariables: mergeVariables(baseVars, config.Variables{
+					"cloud_token":              config.StringVariable(validToken),
+					"resource_organization_id": config.StringVariable(cloudWrongOrg),
+				}),
+				ExpectError: regexp.MustCompile(`cloud token scope violation`),
+			},
+		},
+	})
+}
+
+func mergeVariables(base config.Variables, overrides config.Variables) config.Variables {
+	merged := make(config.Variables, len(base)+len(overrides))
+	for key, value := range base {
+		merged[key] = value
+	}
+	for key, value := range overrides {
+		merged[key] = value
+	}
+	return merged
+}
+
+func buildCloudToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"typ":"JWT","alg":"none"}`))
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("failed to marshal cloud token claims: %v", err)
+	}
+
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + "."
+}
+
+func validCloudTokenClaims(envs ...string) map[string]any {
+	if len(envs) == 0 {
+		envs = []string{cloudTestEnv}
+	}
+
+	return map[string]any{
+		"org":    cloudTestOrg,
+		"envs":   envs,
+		"cpg":    "eu",
+		"iss":    "GraviteeCloud",
+		"aud":    "CloudGate",
+		"target": "apim",
+		"scopes": []string{"automation", "rest"},
+	}
+}

--- a/tests/acceptance/testdata/TestCloudAuthScope_rejectsUnauthorizedScope/main.tf
+++ b/tests/acceptance/testdata/TestCloudAuthScope_rejectsUnauthorizedScope/main.tf
@@ -1,0 +1,42 @@
+provider "apim" {
+  cloud_auth      = var.cloud_token
+  server_url      = "http://127.0.0.1:9/automation"
+  organization_id = var.provider_organization_id
+  environment_id  = var.provider_environment_id
+}
+
+variable "cloud_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "provider_organization_id" {
+  type    = string
+  default = "DEFAULT"
+}
+
+variable "provider_environment_id" {
+  type    = string
+  default = "DEFAULT"
+}
+
+variable "hrid" {
+  type = string
+}
+
+variable "resource_organization_id" {
+  type    = string
+  default = null
+}
+
+variable "resource_environment_id" {
+  type    = string
+  default = null
+}
+
+resource "apim_group" "test" {
+  hrid            = var.hrid
+  name            = "Test"
+  organization_id = var.resource_organization_id
+  environment_id  = var.resource_environment_id
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2961

## Summary

- Add an HTTP transport that validates `organization_id` and `environment_id` from outgoing API URLs against Gravitee Cloud token claims.
- Extend cloud initialization to expose parsed token claims and share scope validation with provider configure.
- Block apply-time requests when a resource targets an environment or organization not permitted by the cloud token, without modifying generated resource CRUD code.

## Test plan

- [x] `go test ./internal/provider/...`
- [x] Confirm `terraform apply` fails when `cloud_auth` is scoped to env A and a resource sets `environment_id` to env B
- [x] Confirm self-hosted (`bearer_auth`) behavior is unchanged