### PR TITLE
fix(GKO-3100): suppress empty response_templates.headers map drift

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: b5451c3d-2473-444c-bd62-9bf8987cd90b
 management:
-  docChecksum: 4c55138f59d17c126a8b2fb86b4a50aa
+  docChecksum: f896c23713092ebe8c7c15a4f4ca0022
   docVersion: 1.0.0
   speakeasyVersion: 1.786.1
   generationVersion: 2.913.3
   releaseVersion: 1.0.0
   configChecksum: e4e0dd4531b872006ef64c6bc4d96ead
 persistentEdits:
-  generation_id: 869727c8-f6a6-4883-8626-3ec7fce7df7c
-  pristine_commit_hash: f3b8dcebad9130cf287da3cc50072e5f618e0b40
-  pristine_tree_hash: d5410224ae83c3a70af4cee0b6980a6288ed226b
+  generation_id: 63da2bd8-de59-4b36-9ebe-04c04035918e
+  pristine_commit_hash: 209bc3698ac6a1a94ed081ad327fcf032630e968
+  pristine_tree_hash: 26ae587810b7abee5bfd65a7032886c525ae3466
 features:
   terraform:
     additionalDependencies: 0.1.0
@@ -236,8 +236,8 @@ trackedFiles:
     pristine_git_object: 22355e514c392cfa9df4645bef9d3cc7eb3cb308
   internal/provider/apiv4_resource.go:
     id: 333e3a57e1ff
-    last_write_checksum: sha1:80f6ca62643c7eaaa6cfb36efa7e40212bb3db1c
-    pristine_git_object: 220fa2cdcdd7290d23c56945453ed1e5783de4ef
+    last_write_checksum: sha1:ca32f84895345b2cd38a76ea38114eec5a329b71
+    pristine_git_object: a76676aeb6d71d3b86ab4f52ca75f4319fa1d65c
   internal/provider/apiv4_resource_sdk.go:
     id: ba8026d69f87
     last_write_checksum: sha1:8371082b7f6e75d791c61b51326617183024fe7b
@@ -292,7 +292,7 @@ trackedFiles:
     pristine_git_object: 82a8266240c0a51f132fcb29c88ec4679649ad08
   internal/provider/provider.go:
     id: 1e7e86841cf3
-    last_write_checksum: sha1:45c95fc474a4b5c710849a16808448d0fc9409aa
+    last_write_checksum: sha1:dd0c04e006646bfbc47d66e190491506713350e3
     pristine_git_object: c2778feb2568c75764140322353ef7d5dd0506d8
   internal/provider/reflect/diags.go:
     id: 35b6b44972e2

--- a/.speakeasy/output/computed.yaml
+++ b/.speakeasy/output/computed.yaml
@@ -752,6 +752,7 @@ components:
             additionalProperties:
               $ref: "#/components/schemas/ResponseTemplate"
           x-speakeasy-param-computed: false
+          x-speakeasy-plan-modifiers: ResponseTemplate
         services:
           $ref: "#/components/schemas/ApiServices"
           x-speakeasy-param-computed: true

--- a/.speakeasy/overlays/apiv4.yaml
+++ b/.speakeasy/overlays/apiv4.yaml
@@ -108,6 +108,10 @@ actions:
     update:
       x-speakeasy-param-computed: true
       x-speakeasy-param-suppress-computed-diff: true
+  - target: $.components.schemas.ApiV4Spec.properties.responseTemplates
+    description: Prevent empty response_templates.headers map from creating plan diff (GKO-3100)
+    update:
+      x-speakeasy-plan-modifiers: ResponseTemplate
   - target: $.components.schemas.Analytics
     description: API return some stuff, need to ignore
     update:

--- a/internal/planmodifiers/mapplanmodifier/response_template.go
+++ b/internal/planmodifiers/mapplanmodifier/response_template.go
@@ -1,0 +1,156 @@
+package mapplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// ResponseTemplate returns a plan modifier for `apim_apiv4.response_templates`.
+//
+// It mirrors IgnoreEmptyList for empty maps, and also suppresses the GKO-3100
+// drift where config sets `headers = {}` but Read maps it back to `null`.
+func ResponseTemplate() planmodifier.Map {
+	return responseTemplate{}
+}
+
+type responseTemplate struct{}
+
+// Description returns a human-readable description of the plan modifier.
+func (m responseTemplate) Description(_ context.Context) string {
+	return "Suppresses empty response_templates.headers map drift"
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m responseTemplate) MarkdownDescription(_ context.Context) string {
+	return "Suppresses perpetual plan diffs when `response_templates.*.*.headers` is set to `{}` but APIM returns `null`."
+}
+
+// PlanModifyMap implements the plan modification logic.
+func (m responseTemplate) PlanModifyMap(ctx context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
+	// nothing set and plan is {} then use state value
+	// (same semantics as IgnoreEmptyList).
+	if req.ConfigValue.IsNull() && !req.StateValue.IsNull() && len(req.StateValue.Elements()) == 0 {
+		resp.PlanValue = req.StateValue
+		return
+	}
+
+	// Special-case suppression for the APIV4 `response_templates.*.*.headers`
+	// drift described in GKO-3100.
+	//
+	// When config sets `headers = {}` (empty map), APIM can persist it but the
+	// provider Read maps it back to `null`. This produces a perpetual plan diff.
+	//
+	// We can’t attach a plan modifier directly to nested `headers` with the
+	// current generated schema, so we apply this modifier on the whole
+	// `response_templates` map and detect the specific “only headers differs”
+	// pattern.
+	if req.ConfigValue.IsNull() || req.StateValue.IsNull() || req.ConfigValue.IsUnknown() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	if ignoreEmptyResponseTemplatesHeadersDiff(req.ConfigValue, req.StateValue) {
+		resp.PlanValue = req.StateValue
+	}
+}
+
+func ignoreEmptyResponseTemplatesHeadersDiff(configValue, stateValue attr.Value) bool {
+	configMap, ok := configValue.(basetypes.MapValue)
+	if !ok {
+		return false
+	}
+	stateMap, ok := stateValue.(basetypes.MapValue)
+	if !ok {
+		return false
+	}
+
+	// Outer keys: template code (e.g. INVALID_HTTP_METHOD)
+	configOuterElements := configMap.Elements()
+	stateOuterElements := stateMap.Elements()
+
+	// Require identical key sets so we never hide additions/removals.
+	if len(configOuterElements) != len(stateOuterElements) {
+		return false
+	}
+
+	for templateCode, configInnerAttr := range configOuterElements {
+		stateInnerAttr, ok := stateOuterElements[templateCode]
+		if !ok {
+			return false
+		}
+
+		configInnerMap, ok := configInnerAttr.(basetypes.MapValue) // content-type -> ResponseTemplate object
+		if !ok {
+			return false
+		}
+		stateInnerMap, ok := stateInnerAttr.(basetypes.MapValue)
+		if !ok {
+			return false
+		}
+
+		configInnerElements := configInnerMap.Elements()
+		stateInnerElements := stateInnerMap.Elements()
+
+		if len(configInnerElements) != len(stateInnerElements) {
+			return false
+		}
+
+		for contentType, configTemplateObjAttr := range configInnerElements {
+			stateTemplateObjAttr, ok := stateInnerElements[contentType]
+			if !ok {
+				return false
+			}
+
+			configTemplateObj, ok := configTemplateObjAttr.(basetypes.ObjectValue)
+			if !ok {
+				return false
+			}
+			stateTemplateObj, ok := stateTemplateObjAttr.(basetypes.ObjectValue)
+			if !ok {
+				return false
+			}
+
+			configObjAttrs := configTemplateObj.Attributes()
+			stateObjAttrs := stateTemplateObj.Attributes()
+
+			// Validate other fields are equal; otherwise we could hide real diffs.
+			if !configObjAttrs["status"].Equal(stateObjAttrs["status"]) {
+				return false
+			}
+			if !configObjAttrs["body"].Equal(stateObjAttrs["body"]) {
+				return false
+			}
+			if !configObjAttrs["propagate_error_key_to_logs"].Equal(stateObjAttrs["propagate_error_key_to_logs"]) {
+				return false
+			}
+
+			// headers: config has empty map {}, state has null.
+			configHeadersAttr := configObjAttrs["headers"]
+			stateHeadersAttr := stateObjAttrs["headers"]
+
+			configHeadersMap, ok := configHeadersAttr.(basetypes.MapValue)
+			if !ok {
+				return false
+			}
+			stateHeadersMap, ok := stateHeadersAttr.(basetypes.MapValue)
+			if !ok {
+				return false
+			}
+
+			if configHeadersMap.IsNull() {
+				return false
+			}
+
+			if len(configHeadersMap.Elements()) == 0 && stateHeadersMap.IsNull() {
+				continue
+			}
+
+			// If headers aren’t the exact drift pattern, don’t suppress.
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/planmodifiers/mapplanmodifier/response_template_test.go
+++ b/internal/planmodifiers/mapplanmodifier/response_template_test.go
@@ -1,0 +1,302 @@
+package mapplanmodifier_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	"github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/mapplanmodifier"
+)
+
+var responseTemplateAttrTypes = map[string]attr.Type{
+	"status":                      types.Int64Type,
+	"headers":                     types.MapType{ElemType: types.StringType},
+	"body":                        types.StringType,
+	"propagate_error_key_to_logs": types.BoolType,
+}
+
+var responseTemplateType = types.ObjectType{AttrTypes: responseTemplateAttrTypes}
+
+func newResponseTemplateObject(t *testing.T, status int64, body string, propagate bool, headers basetypes.MapValue) basetypes.ObjectValue {
+	t.Helper()
+
+	obj, diags := basetypes.NewObjectValue(responseTemplateAttrTypes, map[string]attr.Value{
+		"status":                      basetypes.NewInt64Value(status),
+		"headers":                     headers,
+		"body":                        basetypes.NewStringValue(body),
+		"propagate_error_key_to_logs": basetypes.NewBoolValue(propagate),
+	})
+	if diags.HasError() {
+		t.Fatalf("failed to build response template object: %v", diags)
+	}
+	return obj
+}
+
+func newResponseTemplatesMap(t *testing.T, templates map[string]map[string]basetypes.ObjectValue) basetypes.MapValue {
+	t.Helper()
+
+	outerElementType := types.MapType{ElemType: responseTemplateType}
+	outer := make(map[string]attr.Value, len(templates))
+	for code, contentTypes := range templates {
+		inner := make(map[string]attr.Value, len(contentTypes))
+		for contentType, obj := range contentTypes {
+			inner[contentType] = obj
+		}
+		innerMap, diags := basetypes.NewMapValue(responseTemplateType, inner)
+		if diags.HasError() {
+			t.Fatalf("failed to build content-type map for %q: %v", code, diags)
+		}
+		outer[code] = innerMap
+	}
+
+	outerMap, diags := basetypes.NewMapValue(outerElementType, outer)
+	if diags.HasError() {
+		t.Fatalf("failed to build response_templates map: %v", diags)
+	}
+	return outerMap
+}
+
+func emptyHeaders(t *testing.T) basetypes.MapValue {
+	t.Helper()
+	m, diags := basetypes.NewMapValue(types.StringType, map[string]attr.Value{})
+	if diags.HasError() {
+		t.Fatalf("failed to build empty headers map: %v", diags)
+	}
+	return m
+}
+
+func nullHeaders() basetypes.MapValue {
+	return basetypes.NewMapNull(types.StringType)
+}
+
+func nonEmptyHeaders(t *testing.T) basetypes.MapValue {
+	t.Helper()
+	m, diags := basetypes.NewMapValue(types.StringType, map[string]attr.Value{
+		"X-Error": basetypes.NewStringValue("boom"),
+	})
+	if diags.HasError() {
+		t.Fatalf("failed to build non-empty headers map: %v", diags)
+	}
+	return m
+}
+
+func runResponseTemplatePlanModify(config, state, plan basetypes.MapValue) basetypes.MapValue {
+	req := planmodifier.MapRequest{
+		ConfigValue: config,
+		StateValue:  state,
+		PlanValue:   plan,
+	}
+	resp := &planmodifier.MapResponse{PlanValue: plan}
+	mapplanmodifier.ResponseTemplate().PlanModifyMap(context.Background(), req, resp)
+	return resp.PlanValue
+}
+
+func TestResponseTemplate_PlanModifyMap(t *testing.T) {
+	t.Parallel()
+
+	emptyMap, _ := basetypes.NewMapValue(types.StringType, map[string]attr.Value{})
+	nonEmptyMap, _ := basetypes.NewMapValue(types.StringType, map[string]attr.Value{
+		"key": basetypes.NewStringValue("value"),
+	})
+	nullMap := basetypes.NewMapNull(types.StringType)
+	unknownMap := basetypes.NewMapUnknown(types.StringType)
+
+	testCases := map[string]struct {
+		configValue   basetypes.MapValue
+		stateValue    basetypes.MapValue
+		planValue     basetypes.MapValue
+		expectedValue basetypes.MapValue
+	}{
+		"config null + state empty map - plan gets state value": {
+			configValue:   nullMap,
+			stateValue:    emptyMap,
+			planValue:     nullMap,
+			expectedValue: emptyMap,
+		},
+		"config null + state non-empty map - plan unchanged": {
+			configValue:   nullMap,
+			stateValue:    nonEmptyMap,
+			planValue:     nullMap,
+			expectedValue: nullMap,
+		},
+		"config null + state null - plan unchanged": {
+			configValue:   nullMap,
+			stateValue:    nullMap,
+			planValue:     nullMap,
+			expectedValue: nullMap,
+		},
+		"config set - plan unchanged": {
+			configValue:   nonEmptyMap,
+			stateValue:    emptyMap,
+			planValue:     nonEmptyMap,
+			expectedValue: nonEmptyMap,
+		},
+		"config null + state unknown - plan gets state value": {
+			configValue:   nullMap,
+			stateValue:    unknownMap,
+			planValue:     nullMap,
+			expectedValue: unknownMap,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := runResponseTemplatePlanModify(tc.configValue, tc.stateValue, tc.planValue)
+			if !got.Equal(tc.expectedValue) {
+				t.Errorf("Expected plan value %s, got %s", tc.expectedValue, got)
+			}
+		})
+	}
+}
+
+func TestResponseTemplate_SuppressesResponseTemplateHeadersEmptyMapDrift(t *testing.T) {
+	t.Parallel()
+
+	configObj := newResponseTemplateObject(t, 400, "http method override denied", false, emptyHeaders(t))
+	stateObj := newResponseTemplateObject(t, 400, "http method override denied", false, nullHeaders())
+
+	outerConfig := newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+		"INVALID_HTTP_METHOD": {"*/*": configObj},
+	})
+	outerState := newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+		"INVALID_HTTP_METHOD": {"*/*": stateObj},
+	})
+
+	got := runResponseTemplatePlanModify(outerConfig, outerState, outerConfig)
+	if !got.Equal(outerState) {
+		t.Errorf("Expected plan to be state value; got plan %s, state %s", got, outerState)
+	}
+}
+
+func TestResponseTemplate_DoesNotSuppressRealDiffs(t *testing.T) {
+	t.Parallel()
+
+	baseConfigObj := newResponseTemplateObject(t, 400, "empty headers", false, emptyHeaders(t))
+	baseStateObj := newResponseTemplateObject(t, 400, "empty headers", false, nullHeaders())
+
+	testCases := map[string]struct {
+		config basetypes.MapValue
+		state  basetypes.MapValue
+	}{
+		"status differs": {
+			config: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": newResponseTemplateObject(t, 400, "empty headers", false, emptyHeaders(t))},
+			}),
+			state: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": newResponseTemplateObject(t, 500, "empty headers", false, nullHeaders())},
+			}),
+		},
+		"body differs": {
+			config: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": newResponseTemplateObject(t, 400, "empty headers", false, emptyHeaders(t))},
+			}),
+			state: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": newResponseTemplateObject(t, 400, "different body", false, nullHeaders())},
+			}),
+		},
+		"propagate_error_key_to_logs differs": {
+			config: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": newResponseTemplateObject(t, 400, "empty headers", true, emptyHeaders(t))},
+			}),
+			state: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": newResponseTemplateObject(t, 400, "empty headers", false, nullHeaders())},
+			}),
+		},
+		"headers are non-empty in config": {
+			config: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": newResponseTemplateObject(t, 400, "empty headers", false, nonEmptyHeaders(t))},
+			}),
+			state: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": newResponseTemplateObject(t, 400, "empty headers", false, nullHeaders())},
+			}),
+		},
+		"headers are non-empty in state": {
+			config: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": newResponseTemplateObject(t, 400, "empty headers", false, emptyHeaders(t))},
+			}),
+			state: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": newResponseTemplateObject(t, 400, "empty headers", false, nonEmptyHeaders(t))},
+			}),
+		},
+		"config template missing from state": {
+			config: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": baseConfigObj},
+			}),
+			state: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"OTHER_TEMPLATE": {"*/*": baseStateObj},
+			}),
+		},
+		"state has extra template": {
+			config: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": baseConfigObj},
+			}),
+			state: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS":  {"*/*": baseStateObj},
+				"OTHER_TEMPLATE": {"*/*": baseStateObj},
+			}),
+		},
+		"state has extra content-type": {
+			config: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": baseConfigObj},
+			}),
+			state: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {
+					"*/*":              baseStateObj,
+					"application/json": baseStateObj,
+				},
+			}),
+		},
+		"config content-type missing from state": {
+			config: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {
+					"*/*":              baseConfigObj,
+					"application/json": baseConfigObj,
+				},
+			}),
+			state: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": baseStateObj},
+			}),
+		},
+		"empty config map with non-empty state": {
+			config: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{}),
+			state: newResponseTemplatesMap(t, map[string]map[string]basetypes.ObjectValue{
+				"EMPTY_HEADERS": {"*/*": baseStateObj},
+			}),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := runResponseTemplatePlanModify(tc.config, tc.state, tc.config)
+			if !got.Equal(tc.config) {
+				t.Errorf("Expected plan to remain config (no suppression); got %s", got)
+			}
+		})
+	}
+}
+
+func TestResponseTemplate_Description(t *testing.T) {
+	t.Parallel()
+
+	desc := mapplanmodifier.ResponseTemplate().Description(context.Background())
+	if desc == "" {
+		t.Error("Expected non-empty description")
+	}
+}
+
+func TestResponseTemplate_MarkdownDescription(t *testing.T) {
+	t.Parallel()
+
+	desc := mapplanmodifier.ResponseTemplate().MarkdownDescription(context.Background())
+	if desc == "" {
+		t.Error("Expected non-empty markdown description")
+	}
+}

--- a/internal/provider/apiv4_resource.go
+++ b/internal/provider/apiv4_resource.go
@@ -11,6 +11,7 @@ import (
 	speakeasy_boolplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/boolplanmodifier"
 	custom_listplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/listplanmodifier"
 	speakeasy_listplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/listplanmodifier"
+	custom_mapplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/mapplanmodifier"
 	speakeasy_objectplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/objectplanmodifier"
 	custom_stringplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/stringplanmodifier"
 	speakeasy_stringplanmodifier "github.com/gravitee-io/terraform-provider-apim/internal/planmodifiers/stringplanmodifier"
@@ -2994,6 +2995,9 @@ func (r *Apiv4Resource) Schema(ctx context.Context, req resource.SchemaRequest, 
 			},
 			"response_templates": schema.MapAttribute{
 				Optional: true,
+				PlanModifiers: []planmodifier.Map{
+					custom_mapplanmodifier.ResponseTemplate(),
+				},
 				ElementType: types.MapType{
 					ElemType: types.ObjectType{
 						AttrTypes: map[string]attr.Type{

--- a/tests/acceptance/apiv4_resource_test.go
+++ b/tests/acceptance/apiv4_resource_test.go
@@ -636,6 +636,47 @@ func TestAPIV4Resource_dyn_props(t *testing.T) {
 	})
 }
 
+// Verifies that setting an empty map (`{}`) for
+// `response_templates.<template>.<content-type>.headers` converges (no perpetual plan drift).
+// This is the behavior described in GKO-3100.
+func TestAPIV4Resource_responseTemplates_emptyHeaders_map_idempotency(t *testing.T) {
+	t.Parallel()
+
+	environmentId := "DEFAULT"
+	organizationId := "DEFAULT"
+	randomId := "test-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			// Create.
+			{
+				ProtoV6ProviderFactories: testProviders(),
+				ConfigDirectory:          config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"environment_id":  config.StringVariable(environmentId),
+					"hrid":            config.StringVariable(randomId),
+					"organization_id": config.StringVariable(organizationId),
+				},
+			},
+			// Re-apply the same config: plan must be empty (idempotency check).
+			{
+				ProtoV6ProviderFactories: testProviders(),
+				ConfigDirectory:          config.TestNameDirectory(),
+				ConfigVariables: config.Variables{
+					"environment_id":  config.StringVariable(environmentId),
+					"hrid":            config.StringVariable(randomId),
+					"organization_id": config.StringVariable(organizationId),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 // Verifies that a listener path without trailing slash does not cause permanent drift.
 // APIM normalizes paths by adding a trailing slash, and the provider must suppress
 // the resulting diff to maintain idempotency (GKO-2621).

--- a/tests/acceptance/testdata/TestAPIV4Resource_responseTemplates_emptyHeaders_map_idempotency/main.tf
+++ b/tests/acceptance/testdata/TestAPIV4Resource_responseTemplates_emptyHeaders_map_idempotency/main.tf
@@ -1,0 +1,94 @@
+variable "environment_id" {
+  type = string
+}
+
+variable "hrid" {
+  type = string
+}
+
+variable "organization_id" {
+  type = string
+}
+
+resource "apim_apiv4" "test" {
+  environment_id  = var.environment_id
+  hrid            = var.hrid
+  lifecycle_state = "UNPUBLISHED"
+  name            = "terraform_response_templates_empty_headers"
+  organization_id = var.organization_id
+  state           = "STOPPED"
+  type            = "PROXY"
+  version         = "1"
+  visibility      = "PRIVATE"
+
+  endpoint_groups = [
+    {
+      name = "Default HTTP proxy group"
+      type = "http-proxy"
+      load_balancer = {
+        type = "ROUND_ROBIN"
+      }
+      services = {}
+      endpoints = [
+        {
+          name = "Default HTTP proxy"
+          type = "http-proxy"
+          configuration = jsonencode({
+            target = "https://example.com"
+          })
+          services = {}
+        }
+      ]
+    }
+  ]
+
+  listeners = [
+    {
+      http = {
+        entrypoints = [
+          {
+            type = "http-proxy"
+          }
+        ]
+        paths = [
+          {
+            path = "/${var.hrid}/"
+          }
+        ]
+        type = "HTTP"
+      }
+    }
+  ]
+
+  plans = [
+    {
+      hrid        = "Keyless"
+      description = "No sec"
+      mode        = "STANDARD"
+      name        = "No security"
+      status      = "PUBLISHED"
+      type        = "API"
+      validation  = "AUTO"
+      security = {
+        type = "KEY_LESS"
+      }
+    }
+  ]
+
+  response_templates = {
+    EMPTY_HEADERS = {
+      "*/*" : {
+        status = 400
+
+        # This is the problematic field from GKO-3100:
+        # `headers = {}` causes perpetual plan drift since the API read maps
+        # the empty map back to `null` in state.
+        headers = {}
+
+        body                        = "empty headers"
+        propagate_error_key_to_logs = false
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-3100

## Summary
- Add a `ResponseTemplate` map plan modifier that suppresses perpetual drift when `response_templates.*.*.headers` is set to `{}` but APIM Read returns `null`.
- Add acceptance coverage for the empty-headers idempotency case.
- Regenerate Speakeasy output and wire the modifier into the APIV4 schema.

## Test plan
- [x] Run unit tests: `go test ./internal/planmodifiers/mapplanmodifier`
- [x] Run acceptance test: `TF_ACC=1 go test -run TestAPIV4Resource_responseTemplates_emptyHeaders_map_idempotency -v ./tests/acceptance`
- [x] Confirm re-apply of a config with `headers = {}` produces an empty plan