### PR TITLE
chore: fix OAS comparing version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ APIM_PASSWORD ?= admin
 APIM_API1_USERNAME ?= api1
 APIM_API1_PASSWORD ?= api1
 APIM_SERVER_URL ?= http://localhost:30083/automation
-APIM_OAS_BRANCH=4.12.x
+APIM_OAS_BRANCH=master
 
 .PHONY: speakeasy
 speakeasy: ## Run speakeasy generation with curated examples and docs


### PR DESCRIPTION
## Issue

none

## Description

* OAS comparison was 4.12.x instead of "master"

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

